### PR TITLE
add support for Obj-C interoperability

### DIFF
--- a/ELWebService.xcodeproj/project.pbxproj
+++ b/ELWebService.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		17088ED61C5010EA007ADE1B /* ELWebService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 179C5C5E1AB079980047169F /* ELWebService.framework */; };
 		17088EEB1C501208007ADE1B /* WebServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17088EE91C501208007ADE1B /* WebServiceTests.swift */; };
 		17088EEC1C501208007ADE1B /* RequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17088EEA1C501208007ADE1B /* RequestTests.swift */; };
+		17547AD61C6121E200D4B030 /* ServiceTask+ObjC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17547AD51C6121E200D4B030 /* ServiceTask+ObjC.swift */; };
 		17C96AAB1AB0CBB800D49071 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = 17C96AAA1AB0CBB800D49071 /* LICENSE */; };
 		17D1879E1AB0B173000742BF /* ELWebService.h in Headers */ = {isa = PBXBuildFile; fileRef = 17D187991AB0B173000742BF /* ELWebService.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CAF0AF991C5054DE0007761C /* WebService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17088EDF1C5011FB007ADE1B /* WebService.swift */; };
@@ -39,6 +40,7 @@
 		17088EE31C5011FB007ADE1B /* Request.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
 		17088EE91C501208007ADE1B /* WebServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebServiceTests.swift; sourceTree = "<group>"; };
 		17088EEA1C501208007ADE1B /* RequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestTests.swift; sourceTree = "<group>"; };
+		17547AD51C6121E200D4B030 /* ServiceTask+ObjC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ServiceTask+ObjC.swift"; sourceTree = "<group>"; };
 		179C5C5E1AB079980047169F /* ELWebService.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ELWebService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		17C96AAA1AB0CBB800D49071 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		17D187961AB0B173000742BF /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -119,6 +121,7 @@
 				17088EE01C5011FB007ADE1B /* SessionDataTaskDataSource.swift */,
 				17088EE11C5011FB007ADE1B /* ServiceTaskResult.swift */,
 				17088EE21C5011FB007ADE1B /* ServiceTask.swift */,
+				17547AD51C6121E200D4B030 /* ServiceTask+ObjC.swift */,
 				17088EE31C5011FB007ADE1B /* Request.swift */,
 			);
 			path = Core;
@@ -246,6 +249,7 @@
 				CAF0AF9A1C5054E20007761C /* SessionDataTaskDataSource.swift in Sources */,
 				CAF0AF9D1C5054ED0007761C /* Request.swift in Sources */,
 				CAF0AF991C5054DE0007761C /* WebService.swift in Sources */,
+				17547AD61C6121E200D4B030 /* ServiceTask+ObjC.swift in Sources */,
 				CAF0AF9B1C5054E60007761C /* ServiceTaskResult.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ELWebService.xcodeproj/project.pbxproj
+++ b/ELWebService.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		17088EEB1C501208007ADE1B /* WebServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17088EE91C501208007ADE1B /* WebServiceTests.swift */; };
 		17088EEC1C501208007ADE1B /* RequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17088EEA1C501208007ADE1B /* RequestTests.swift */; };
 		17547AD61C6121E200D4B030 /* ServiceTask+ObjC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17547AD51C6121E200D4B030 /* ServiceTask+ObjC.swift */; };
+		17821A011C623B2D00D3837D /* ObjCInteropTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 17821A001C623B2D00D3837D /* ObjCInteropTests.m */; };
+		17821A031C623D2C00D3837D /* ServiceTask+TestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17821A021C623D2C00D3837D /* ServiceTask+TestUtils.swift */; };
 		17C96AAB1AB0CBB800D49071 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = 17C96AAA1AB0CBB800D49071 /* LICENSE */; };
 		17D1879E1AB0B173000742BF /* ELWebService.h in Headers */ = {isa = PBXBuildFile; fileRef = 17D187991AB0B173000742BF /* ELWebService.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CAF0AF991C5054DE0007761C /* WebService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17088EDF1C5011FB007ADE1B /* WebService.swift */; };
@@ -41,6 +43,9 @@
 		17088EE91C501208007ADE1B /* WebServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebServiceTests.swift; sourceTree = "<group>"; };
 		17088EEA1C501208007ADE1B /* RequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestTests.swift; sourceTree = "<group>"; };
 		17547AD51C6121E200D4B030 /* ServiceTask+ObjC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ServiceTask+ObjC.swift"; sourceTree = "<group>"; };
+		178219FF1C623B2C00D3837D /* ELWebServiceTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ELWebServiceTests-Bridging-Header.h"; sourceTree = "<group>"; };
+		17821A001C623B2D00D3837D /* ObjCInteropTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjCInteropTests.m; sourceTree = "<group>"; };
+		17821A021C623D2C00D3837D /* ServiceTask+TestUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ServiceTask+TestUtils.swift"; sourceTree = "<group>"; };
 		179C5C5E1AB079980047169F /* ELWebService.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ELWebService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		17C96AAA1AB0CBB800D49071 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		17D187961AB0B173000742BF /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -69,9 +74,12 @@
 		17088ED21C5010EA007ADE1B /* ELWebServiceTests */ = {
 			isa = PBXGroup;
 			children = (
-				17088EE91C501208007ADE1B /* WebServiceTests.swift */,
+				17821A001C623B2D00D3837D /* ObjCInteropTests.m */,
 				17088EEA1C501208007ADE1B /* RequestTests.swift */,
+				17821A021C623D2C00D3837D /* ServiceTask+TestUtils.swift */,
+				17088EE91C501208007ADE1B /* WebServiceTests.swift */,
 				17088ED51C5010EA007ADE1B /* Info.plist */,
+				178219FF1C623B2C00D3837D /* ELWebServiceTests-Bridging-Header.h */,
 			);
 			path = ELWebServiceTests;
 			sourceTree = "<group>";
@@ -236,7 +244,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				17821A011C623B2D00D3837D /* ObjCInteropTests.m in Sources */,
 				17088EEC1C501208007ADE1B /* RequestTests.swift in Sources */,
+				17821A031C623D2C00D3837D /* ServiceTask+TestUtils.swift in Sources */,
 				17088EEB1C501208007ADE1B /* WebServiceTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -268,22 +278,27 @@
 		17088EDA1C5010EA007ADE1B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = ELWebServiceTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.electrode.ELWebServiceTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "ELWebServiceTests/ELWebServiceTests-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
 		};
 		17088EDB1C5010EA007ADE1B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = ELWebServiceTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.electrode.ELWebServiceTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "ELWebServiceTests/ELWebServiceTests-Bridging-Header.h";
 			};
 			name = Release;
 		};

--- a/ELWebServiceTests/ELWebServiceTests-Bridging-Header.h
+++ b/ELWebServiceTests/ELWebServiceTests-Bridging-Header.h
@@ -1,0 +1,4 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+

--- a/ELWebServiceTests/ObjCInteropTests.m
+++ b/ELWebServiceTests/ObjCInteropTests.m
@@ -1,0 +1,111 @@
+//
+//  ObjCInteropTests.m
+//  ELWebService
+//
+//  Created by Angelo Di Paolo on 2/2/16.
+//  Copyright © 2016 WalmartLabs. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "ELWebService.h"
+#import "ELWebServiceTests-Swift.h"
+
+@interface ObjCInteropTests : XCTestCase
+
+@end
+
+@implementation ObjCInteropTests
+
+// MARK: - ServiceTask tests
+
+- (void)test_responseObjC_handlerIsCalled {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"response handler is called"];
+    WebService *service = [[WebService alloc] initWithBaseURLString:@"foo"];
+    ServiceTask *task = [service GET:@"bar"];
+    [task responseObjC:^ObjCHandlerResult *(NSData *data, NSURLResponse *response) {
+        [expectation fulfill];
+        return nil;
+    }];
+    
+    [task injectResponse:[NSURLResponse mockResponse] data:nil error:nil];
+    
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
+}
+
+- (void)test_updateUIObjC_receivesHandlerResult {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"updateUI handler is called"];
+    WebService *service = [[WebService alloc] initWithBaseURLString:@"foo"];
+    ServiceTask *task = [service GET:@"bar"];
+    NSString *mockValue = @"12345";
+    [task responseObjC:^ObjCHandlerResult *(NSData *data, NSURLResponse *response) {
+        return [[ObjCHandlerResult alloc] initWithValue:mockValue];
+    }];
+    
+    [task updateUIObjC:^(id value) {
+        XCTAssertTrue([value isKindOfClass:[NSString class]]);
+        XCTAssertEqual(value, mockValue);
+        [expectation fulfill];
+    }];
+    
+    [task injectResponse:[NSURLResponse mockResponse] data:nil error:nil];
+    
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
+}
+
+- (void)test_responseJSONObjC_receivesHandlerResult {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"updateUI handler is called"];
+    WebService *service = [[WebService alloc] initWithBaseURLString:@"foo"];
+    ServiceTask *task = [service GET:@"bar"];
+    [task responseJSONObjC:^ObjCHandlerResult *(id json) {
+        NSDictionary *dictionary = json;
+        XCTAssertTrue([dictionary isKindOfClass:[NSDictionary class]]);
+        XCTAssertTrue([dictionary[@"foo"] isEqualToString:@"bar"]);
+        [expectation fulfill];
+    }];
+    
+    [task injectResponse:[NSURLResponse mockResponse] data:[NSData mockJSONData] error:nil];
+    
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
+}
+
+- (void)test_responseError_calledWhenReturningErrorFromResponseHandler {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"error handler is called"];
+    WebService *service = [[WebService alloc] initWithBaseURLString:@"foo"];
+    ServiceTask *task = [service GET:@"bar"];
+    NSError *mockError = [[NSError alloc] initWithDomain:@"domain" code:500 userInfo:nil];
+    [task responseObjC:^ObjCHandlerResult *(NSData *data, NSURLResponse *response) {
+        return [[ObjCHandlerResult alloc] initWithError:mockError];
+    }];
+    [task responseErrorObjC:^(NSError * error) {
+        XCTAssertNotNil(error);
+        XCTAssertEqual(error.domain, mockError.domain);
+        XCTAssertEqual(error.code, mockError.code);
+        [expectation fulfill];
+    }];
+    
+    [task injectResponse:[NSURLResponse mockResponse] data:nil error:nil];
+
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
+}
+
+- (void)test_updateErrorUI_calledWhenReturningErrorFromResponseHandler {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"error handler is called"];
+    WebService *service = [[WebService alloc] initWithBaseURLString:@"foo"];
+    ServiceTask *task = [service GET:@"bar"];
+    NSError *mockError = [[NSError alloc] initWithDomain:@"domain" code:500 userInfo:nil];
+    [task responseObjC:^ObjCHandlerResult *(NSData *data, NSURLResponse *response) {
+        return [[ObjCHandlerResult alloc] initWithError:mockError];
+    }];
+    [task updateErrorUIObjC:^(NSError * error) {
+        XCTAssertNotNil(error);
+        XCTAssertEqual(error.domain, mockError.domain);
+        XCTAssertEqual(error.code, mockError.code);
+        [expectation fulfill];
+    }];
+
+    [task injectResponse:[NSURLResponse mockResponse] data:nil error:nil];
+    
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
+}
+
+@end

--- a/ELWebServiceTests/ObjCInteropTests.m
+++ b/ELWebServiceTests/ObjCInteropTests.m
@@ -38,7 +38,7 @@
     ServiceTask *task = [service GET:@"bar"];
     NSString *mockValue = @"12345";
     [task responseObjC:^ObjCHandlerResult *(NSData *data, NSURLResponse *response) {
-        return [[ObjCHandlerResult alloc] initWithValue:mockValue];
+        return [ObjCHandlerResult resultWithValue:mockValue];
     }];
     
     [task updateUIObjC:^(id value) {
@@ -74,7 +74,7 @@
     ServiceTask *task = [service GET:@"bar"];
     NSError *mockError = [[NSError alloc] initWithDomain:@"domain" code:500 userInfo:nil];
     [task responseObjC:^ObjCHandlerResult *(NSData *data, NSURLResponse *response) {
-        return [[ObjCHandlerResult alloc] initWithError:mockError];
+        return [ObjCHandlerResult resultWithError:mockError];
     }];
     [task responseErrorObjC:^(NSError * error) {
         XCTAssertNotNil(error);
@@ -94,7 +94,7 @@
     ServiceTask *task = [service GET:@"bar"];
     NSError *mockError = [[NSError alloc] initWithDomain:@"domain" code:500 userInfo:nil];
     [task responseObjC:^ObjCHandlerResult *(NSData *data, NSURLResponse *response) {
-        return [[ObjCHandlerResult alloc] initWithError:mockError];
+        return [ObjCHandlerResult resultWithError:mockError];
     }];
     [task updateErrorUIObjC:^(NSError * error) {
         XCTAssertNotNil(error);

--- a/ELWebServiceTests/ServiceTask+TestUtils.swift
+++ b/ELWebServiceTests/ServiceTask+TestUtils.swift
@@ -1,0 +1,36 @@
+//
+//  ServiceTask+TestUtils.swift
+//  ELWebService
+//
+//  Created by Angelo Di Paolo on 2/3/16.
+//  Copyright © 2016 WalmartLabs. All rights reserved.
+//
+
+import Foundation
+@testable import ELWebService
+
+extension ServiceTask {
+    // expose internal handleResponse method to obj-c tests via injectResponse()
+    @objc public func injectResponse(response: NSURLResponse?, data: NSData?, error: NSError?) {
+        handleResponse(response, data: data, error: error)
+    }
+}
+
+// MARK: - Response Mock
+
+extension NSURLResponse {
+    static func mockResponse() -> NSURLResponse {
+        let url = NSURL(string: "foo")!
+        return NSURLResponse(URL: url, MIMEType: nil, expectedContentLength: 0, textEncodingName: nil)
+    }
+}
+
+// MARK: - Response Data Mock
+
+extension NSData {
+    static func mockJSONData() -> NSData {
+        let json = ["foo": "bar"]
+        let data = try! NSJSONSerialization.dataWithJSONObject(json, options: NSJSONWritingOptions(rawValue:  0))
+        return data
+    }
+}

--- a/ELWebServiceTests/WebServiceTests.swift
+++ b/ELWebServiceTests/WebServiceTests.swift
@@ -382,4 +382,3 @@ class WebServiceTests: XCTestCase {
         waitForExpectationsWithTimeout(2, handler: nil)
     }
 }
-

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # ELWebService [![Build Status](https://travis-ci.org/Electrode-iOS/ELWebService.svg?branch=master)](https://travis-ci.org/Electrode-iOS/ELWebService) [![Carthage Compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
-ELWebService simplifies interaction with HTTP web services by providing a concise API for encoding `NSURLRequest` objects and processing the resulting `NSURLResponse` object. Designed as a lightweight utility for communicating with web services, ELWebService is not intended to be a fully-featured networking library. By default ELWebService uses the shared `NSURLSession` instance to create data tasks but can be configured to work with any `NSURLSession` instance using a [protocol](#sessiondatataskdatasource).
+ELWebService (previously named Swallow) simplifies interaction with HTTP web services by providing a concise API for encoding `NSURLRequest` objects and processing the resulting `NSURLResponse` object. Designed as a lightweight utility for communicating with web services, ELWebService is not intended to be a fully-featured networking library. By default ELWebService uses the shared `NSURLSession` instance to create data tasks but can be configured to work with any `NSURLSession` instance using a [protocol](#sessiondatataskdatasource).
 
-See the [Programming Guide](/docs/Programming-Guide.md) for more information. 
+See the [ELWebService Programming Guide](/docs/Programming-Guide.md) for more information. 
 
 ## Requirements
 
-ELWebService requires Swift 2 and Xcode 7. For Xcode 6 and Swift 1.2 compatability use the latest [v0.0.x](https://github.com/Electrode-iOS/ELWebService/releases/tag/v0.0.3) release.
+ELWebService requires Swift 2.1 and Xcode 7.2.
 
 ## Installation
 
@@ -272,7 +272,27 @@ service
     .resume()
 ```
 
-## Example
+### Objective-C Interoperability
+
+ELWebService supports Objective-C via specially-named response handler methods. See the [Objective-C Interoperability section](/docs/Programming-Guide.md#objective-c-interoperability) in the [ELWebService Programming Guide](/docs/Programming-Guide.md) for more information. 
+
+```
+extension ServiceTask {
+    internal typealias ObjCResponseHandler = (NSData?, NSURLResponse?) -> ObjCHandlerResult?
+
+    @objc public func responseObjC(handler: (NSData?, NSURLResponse?) -> ObjCHandlerResult?) -> Self
+
+    @objc public func responseJSONObjC(handler: (AnyObject) -> ObjCHandlerResult?) -> Self
+
+    @objc public func responseErrorObjC(handler: (NSError) -> Void) -> Self
+
+    @objc public func updateUIObjC(handler: (AnyObject?) -> Void) -> Self
+
+    @objc public func updateErrorUIObjC(handler: (NSError) -> Void) -> Self
+}
+```
+
+## Example Project
 
 An [example project](/ELWebServiceExample) is included that demonstrates how ELWebService can be used to interact with a web service. The project uses [brewhapi](https://github.com/angelodipaolo/brewhapi) as a mock API for fetching and inserting data. brewhapi is freely hosted at [https://brewhapi.herokuapp.com/brews](https://brewhapi.herokuapp.com/brews) for testing.
 
@@ -286,7 +306,7 @@ When contributing code, please refer to our style guide [Dennis](https://github.
 
 The MIT License (MIT)
 
-Copyright (c) 2015 Walmart, Electrode-iOS, and other Contributors
+Copyright (c) 2015 Walmart and other Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Source/Core/ServiceTask+ObjC.swift
+++ b/Source/Core/ServiceTask+ObjC.swift
@@ -1,0 +1,65 @@
+//
+//  ServiceTask+ObjC.swift
+//  ELWebService
+//
+//  Created by Angelo Di Paolo on 2/2/16.
+//  Copyright © 2016 WalmartLabs. All rights reserved.
+//
+
+import Foundation
+
+/// Response handler methods that add Obj-C interopability 
+extension ServiceTask {
+    typealias ObjCResponseHandler = (NSData?, NSURLResponse?) -> ObjCHandlerResult?
+
+    /**
+     Add a response handler to be called on a background thread after a successful
+     response has been received. This method is designed to be called from Obj-C.
+     Please use `response(handler: ResponseProcessingHandler) -> Self` when calling
+     from Swift.
+     
+     - parameter handler: Response handler to execute upon receiving a response.
+     - returns: Self instance to support chaining.
+     */
+    @objc public func responseObjC(handler: (NSData?, NSURLResponse?) -> ObjCHandlerResult?) -> Self {
+        return response { data, response in
+            return ServiceTaskResult(objCHandlerResult: handler(data, response))
+        }
+    }
+    
+    /**
+     Add a response handler to serialize the response body as a JSON object. The
+     handler will be dispatched to a background thread.
+     
+     - parameter handler: Response handler to execute upon receiving a response.
+     - returns: Self instance to support chaining.
+     */
+    @objc public func responseJSONObjC(handler: (AnyObject) -> ObjCHandlerResult?) -> Self {
+        return responseJSON { json in
+            return ServiceTaskResult(objCHandlerResult: handler(json))
+        }
+    }
+    
+    // TODO: write docs
+    @objc public func responseErrorObjC(handler: (NSError) -> Void) -> Self {
+        return responseError { error in
+            handler(error as NSError)
+        }
+    }
+    
+    // TODO: write docs
+    @objc public func updateUIObjC(handler: (AnyObject?) -> Void) -> Self {
+        return updateUI { value in
+            if let value = value as? AnyObject {
+                handler(value)
+            }
+        }
+    }
+    
+    // TODO: write docs
+    @objc public func updateErrorUIObjC(handler: (NSError) -> Void) -> Self {
+        return updateErrorUI { error in
+            handler(error as NSError)
+        }
+    }
+}

--- a/Source/Core/ServiceTask+ObjC.swift
+++ b/Source/Core/ServiceTask+ObjC.swift
@@ -10,6 +10,8 @@ import Foundation
 
 /// Response handler methods that add Obj-C interopability 
 extension ServiceTask {
+    
+    /// Response handler type for Obj-C
     typealias ObjCResponseHandler = (NSData?, NSURLResponse?) -> ObjCHandlerResult?
 
     /**
@@ -29,7 +31,9 @@ extension ServiceTask {
     
     /**
      Add a response handler to serialize the response body as a JSON object. The
-     handler will be dispatched to a background thread.
+     handler will be dispatched to a background thread. This method is designed 
+     to be called from Obj-C. Please use `responseJSON(handler: JSONHandler) -> Self` 
+     when calling from Swift.
      
      - parameter handler: Response handler to execute upon receiving a response.
      - returns: Self instance to support chaining.
@@ -40,14 +44,35 @@ extension ServiceTask {
         }
     }
     
-    // TODO: write docs
+    /**
+     Add a response handler to be called if a request results in an error.
+     
+     This method is designed to be called from Obj-C. Please use 
+     `responseError(handler: ErrorHandler)` when calling from Swift.
+     
+     - parameter handler: Error handler to execute when an error occurs.
+     - returns: Self instance to support chaining.
+    */
     @objc public func responseErrorObjC(handler: (NSError) -> Void) -> Self {
         return responseError { error in
             handler(error as NSError)
         }
     }
     
-    // TODO: write docs
+    /**
+     Add a handler that runs on the main thread and is responsible for updating
+     the UI with a given value. The handler is only called if a previous response
+     handler in the chain does **not** return a `.Failure` value.
+     
+     If a response handler returns a value via `[ObjCHandlerResult resultWithValue:someValue]`
+     the value will be passed to the update UI handler.
+     
+     This method is designed to be called from Obj-C. Please use
+     `updateUI(handler: UpdateUIHandler) -> Self` when calling from Swift.
+     
+     - parameter handler: The closure to execute as the updateUI handler.
+     - returns: Self instance to support chaining.
+    */
     @objc public func updateUIObjC(handler: (AnyObject?) -> Void) -> Self {
         return updateUI { value in
             if let value = value as? AnyObject {
@@ -56,7 +81,16 @@ extension ServiceTask {
         }
     }
     
-    // TODO: write docs
+    /**
+     Add a response handler to be called if a request results in an error. Handler
+     will be called on the main thread.
+     
+     This method is designed to be called from Obj-C. Please use
+     `updateErrorUIObjC(handler: (NSError) -> Void) -> Self` when calling from Swift.
+     
+     - parameter handler: Error handler to execute when an error occurs.
+     - returns: Self instance to support chaining.
+    */
     @objc public func updateErrorUIObjC(handler: (NSError) -> Void) -> Self {
         return updateErrorUI { error in
             handler(error as NSError)

--- a/Source/Core/ServiceTask.swift
+++ b/Source/Core/ServiceTask.swift
@@ -183,7 +183,17 @@ extension ServiceTask {
         return self
     }
     
-    /// TODO: add docs
+    /**
+     Add a handler that runs on the main thread and is responsible for updating 
+     the UI with a given value. The handler is only called if a previous response 
+     handler in the chain does **not** return a `.Failure` value.
+     
+     If a response handler returns a value via ServiceTaskResult.Value the
+     associated value will be passed to the update UI handler.
+    
+     - parameter handler: The closure to execute as the updateUI handler.
+     - returns: Self instance to support chaining.
+    */
     public func updateUI(handler: UpdateUIHandler) -> Self {
         dispatch_async(handlerQueue) {
             if let taskResult = self.taskResult {
@@ -261,11 +271,11 @@ extension ServiceTask {
     
     /**
      Add a response handler to be called if a request results in an error. Handler
-     will be called on the main queue.
+     will be called on the main thread.
      
      - parameter handler: Error handler to execute when an error occurs.
      - returns: Self instance to support chaining.
-     */
+    */
     public func updateErrorUI(handler: ErrorHandler) -> Self {
         dispatch_async(handlerQueue) {
             if let taskResult = self.taskResult {
@@ -286,7 +296,8 @@ extension ServiceTask {
 
 // MARK: - Errors
 
-// TODO: needs docs
+/// Errors that can occur when processing a response
 public enum ServiceTaskError: ErrorType {
+    /// Failed to serialize a response body as JSON due to the data being nil.
     case JSONSerializationFailedNilResponseBody
 }

--- a/Source/Core/ServiceTask.swift
+++ b/Source/Core/ServiceTask.swift
@@ -14,7 +14,7 @@ import Foundation
  cancelled and suspended like a data task as well as queried for current state
  via the `state` property.
 */
-public final class ServiceTask {
+@objc public final class ServiceTask: NSObject {
     private var request: Request
     
     public typealias ResponseProcessingHandler = (NSData?, NSURLResponse?) -> ServiceTaskResult
@@ -119,7 +119,6 @@ extension ServiceTask {
     }
 }
 
-
 // MARK: NSURLSesssionDataTask
 
 extension ServiceTask {
@@ -161,11 +160,11 @@ extension ServiceTask {
 
 extension ServiceTask {
     /**
-    Add a response handler to be called on the main thread after a successful
-    response has been received.
+     Add a response handler to be called on background thread after a successful
+     response has been received.
     
-    - parameter handler: Response handler to execute upon receiving a response.
-    - returns: Self instance to support chaining.
+     - parameter handler: Response handler to execute upon receiving a response.
+     - returns: Self instance to support chaining.
     */
     public func response(handler: ResponseProcessingHandler) -> Self {
         dispatch_async(handlerQueue) {
@@ -183,6 +182,7 @@ extension ServiceTask {
         return self
     }
     
+    /// TODO: add docs
     public func updateUI(handler: UpdateUIHandler) -> Self {
         dispatch_async(handlerQueue) {
             if let taskResult = self.taskResult {
@@ -204,7 +204,6 @@ extension ServiceTask {
     }
 }
 
-
 // MARK: - JSON
 
 extension ServiceTask {
@@ -213,7 +212,7 @@ extension ServiceTask {
     
     /**
      Add a response handler to serialize the response body as a JSON object. The
-     handler will be dispatched to the main thread.
+     handler will be dispatched to a background thread.
     
      - parameter handler: Response handler to execute upon receiving a response.
      - returns: Self instance to support chaining.
@@ -242,8 +241,8 @@ extension ServiceTask {
     /**
     Add a response handler to be called if a request results in an error.
     
-    :param: handler Error handler to execute when an error occurs.
-    :returns: Self instance to support chaining.
+    - parameter handler: Error handler to execute when an error occurs.
+    - returns: Self instance to support chaining.
     */
     public func responseError(handler: ErrorHandler) -> Self {
         dispatch_async(handlerQueue) {
@@ -263,8 +262,8 @@ extension ServiceTask {
      Add a response handler to be called if a request results in an error. Handler
      will be called on the main queue.
      
-     :param: handler Error handler to execute when an error occurs.
-     :returns: Self instance to support chaining.
+     - parameter handler: Error handler to execute when an error occurs.
+     - returns: Self instance to support chaining.
      */
     public func updateErrorUI(handler: ErrorHandler) -> Self {
         dispatch_async(handlerQueue) {
@@ -282,16 +281,11 @@ extension ServiceTask {
         
         return self
     }
-    
-    /**
-     Call to indicate that an error occured during the processing of a response.
-     Causes responseError handlers to be called.
-    */
-//    public func throwError(error: ErrorType) {
-//        self.result = .Failure(error)
-//    }
 }
 
+// MARK: - Errors
+
+// TODO: needs docs
 public enum ServiceTaskError: ErrorType {
     case JSONSerializationFailedNilResponseBody
 }

--- a/Source/Core/ServiceTaskResult.swift
+++ b/Source/Core/ServiceTaskResult.swift
@@ -17,3 +17,37 @@ public enum ServiceTaskResult {
     /// Defines a task resulting in an error
     case Failure(ErrorType)
 }
+
+// MARK: - Objective-C Interop
+
+extension ServiceTaskResult {
+    /// Initialize a service task result value from an Obj-C result
+    init(objCHandlerResult result: ObjCHandlerResult?) {
+        if let error = result?.error {
+            self = .Failure(error)
+        } else if let value = result?.value {
+            self = .Value(value)
+        } else {
+            self = .Empty
+        }
+    }
+}
+
+/// Represents the result of a Obj-C response handler
+@objc public final class ObjCHandlerResult: NSObject {
+    /// The resulting value
+    private(set) var value: AnyObject?
+    
+    /// The resulting error
+    private(set) var error: NSError?
+    
+    /// Initialize a result with a value
+    @objc public init(value: AnyObject) {
+        self.value = value
+    }
+    
+    /// Initialize a result with an error
+    @objc public init(error: NSError) {
+        self.error = error
+    }
+}

--- a/Source/Core/ServiceTaskResult.swift
+++ b/Source/Core/ServiceTaskResult.swift
@@ -41,13 +41,21 @@ extension ServiceTaskResult {
     /// The resulting error
     private(set) var error: NSError?
     
+    public class func resultWithValue(value: AnyObject) -> ObjCHandlerResult {
+        return ObjCHandlerResult(value: value)
+    }
+    
+    public class func resultWithError(error: NSError) -> ObjCHandlerResult {
+        return ObjCHandlerResult(error: error)
+    }
+    
     /// Initialize a result with a value
-    @objc public init(value: AnyObject) {
+    private init(value: AnyObject) {
         self.value = value
     }
     
     /// Initialize a result with an error
-    @objc public init(error: NSError) {
+    private init(error: NSError) {
         self.error = error
     }
 }

--- a/Source/Core/WebService.swift
+++ b/Source/Core/WebService.swift
@@ -12,7 +12,7 @@ import Foundation
  A `WebService` value provides a concise API for encoding a NSURLRequest object
  and processing the resulting `NSURLResponse` object.
 */
-public final class WebService {
+@objc public final class WebService: NSObject {
     /// Base URL of the web service.
     public let baseURLString: String
     


### PR DESCRIPTION
This PR adds support for Obj-C interoperability by implementing option 3 of the [proposed solutions](https://github.com/Electrode-iOS/ELWebService/issues/21#issuecomment-178642922)

- Make `WebService` inherit from NSObject
- Make `ServiceTask` inherit from NSObject
- Add `ObjCHandlerResult` class to encapsulate result data from Obj-C handlers
- Add `ObjCResponseHandler` closure type to support adding response handlers that work with Obj-C
- Extend `ServiceTask` to add specially-named response handler methods to support adding handlers from Obj-C
- Add a `ServiceTaskResult` initializer so that a service task result value can be initialized from an `ObjCHandlerResult` value