### PR TITLE
Add NSURLResponse to jsonResponseHandler

### DIFF
--- a/ELWebServiceTests/ObjCInteropTests.m
+++ b/ELWebServiceTests/ObjCInteropTests.m
@@ -56,7 +56,7 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"updateUI handler is called"];
     WebService *service = [[WebService alloc] initWithBaseURLString:@"foo"];
     ServiceTask *task = [service GET:@"bar"];
-    [task responseJSONObjC:^ObjCHandlerResult *(id json) {
+    [task responseJSONObjC:^ObjCHandlerResult *(id json, NSURLResponse *response) {
         NSDictionary *dictionary = json;
         XCTAssertTrue([dictionary isKindOfClass:[NSDictionary class]]);
         XCTAssertTrue([dictionary[@"foo"] isEqualToString:@"bar"]);

--- a/ELWebServiceTests/WebServiceTests.swift
+++ b/ELWebServiceTests/WebServiceTests.swift
@@ -32,8 +32,8 @@ class WebServiceTests: XCTestCase {
         }
     }
     
-    func jsonResponseHandler(expectation expectation: XCTestExpectation) -> (AnyObject) -> ServiceTaskResult {
-        return { json in
+    func jsonResponseHandler(expectation expectation: XCTestExpectation) -> (AnyObject, NSURLResponse?) -> ServiceTaskResult {
+        return { json, response in
             XCTAssertTrue(!NSThread.isMainThread())
 
             if json is NSDictionary {
@@ -226,7 +226,7 @@ class WebServiceTests: XCTestCase {
                 
                 return .Empty
             }
-            .responseJSON { json in
+            .responseJSON { json, response in
                 let castedJSON = json as? [String : AnyObject]
                 XCTAssert(castedJSON != nil)
 
@@ -260,7 +260,7 @@ class WebServiceTests: XCTestCase {
                 
                 return .Empty
             }
-            .responseJSON { json in
+            .responseJSON { json, response in
                 let castedJSON = json as? [String : AnyObject]
                 XCTAssert(castedJSON != nil)
                 
@@ -293,7 +293,7 @@ class WebServiceTests: XCTestCase {
                 
                 return .Empty
             }
-            .responseJSON { json in
+            .responseJSON { json, response in
                 let castedJSON = json as? [String : AnyObject]
                 XCTAssert(castedJSON != nil)
                 
@@ -329,7 +329,7 @@ class WebServiceTests: XCTestCase {
                 
                 return .Empty
             }
-            .responseJSON { json in
+            .responseJSON { json, reponse in
                 let castedJSON = json as? [String : AnyObject]
                 XCTAssert(castedJSON != nil)
                 
@@ -364,7 +364,7 @@ class WebServiceTests: XCTestCase {
                 
                 return .Empty
             }
-            .responseJSON { json in
+            .responseJSON { json, repsponse in
                 let castedJSON = json as? [String : AnyObject]
                 XCTAssert(castedJSON != nil)
                 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ELWebService (previously named Swallow) simplifies interaction with HTTP web services by providing a concise API for encoding `NSURLRequest` objects and processing the resulting `NSURLResponse` object. Designed as a lightweight utility for communicating with web services, ELWebService is not intended to be a fully-featured networking library. By default ELWebService uses the shared `NSURLSession` instance to create data tasks but can be configured to work with any `NSURLSession` instance using a [protocol](#sessiondatataskdatasource).
 
-See the [ELWebService Programming Guide](/docs/Programming-Guide.md) for more information. 
+See the [ELWebService Programming Guide](/docs/Programming-Guide.md) for more information.
 
 ## Requirements
 
@@ -72,7 +72,7 @@ let service = WebService(baseURLString: "https://brewhapi.herokuapp.com/")
 service
   .GET("/brewers")
   .setParameters(["state" : "New York"])
-  .responseJSON { (json: AnyObject) in
+  .responseJSON { (json: AnyObject, response: NSURLResponse?) in
     // process response as JSON
   }
   .resume()
@@ -115,7 +115,7 @@ Send a `POST` request with body parameters.
 ```
 let service = WebService(baseURLString: "http://httpbin.org")
 let parameters = ["foo" : "bar", "percentEncoded" : "this needs percent encoded"]
-        
+
 service
     .POST("/post")
     .setParameters(parameters)
@@ -137,7 +137,7 @@ Send a `POST` request with JSON encoded parameters.
 let service = WebService(baseURLString: "http://httpbin.org")
 
 service
-    .POST("/post") 
+    .POST("/post")
     .setParameters(["foo" : "bar", "number" : 42], encoding: .JSON)
     .resume()
 ```
@@ -158,7 +158,7 @@ Alternatively you can specify the explicit JSON payload to send as the request b
 let service = WebService(baseURLString: "http://httpbin.org")
 
 service
-    .POST("/post") 
+    .POST("/post")
     .setJSON(["hmm": ["foo" : "bar", "number" : 42]])
     .resume()
 ```
@@ -196,12 +196,12 @@ let service = WebService(baseURLString: "https://somehapi.herokuapp.com")
 
 service
     .GET("/brewers")
-    .responseJSON { json in
+    .responseJSON { json, response in
         if let models: [Brewer] = JSONDecoder<Brewer>.decode(json)  {
             return .Value(models)
         } else {
           // any value conforming to ErrorType
-          return .Failure(JSONDecoderError.FailedToDecodeBrewer) 
+          return .Failure(JSONDecoderError.FailedToDecodeBrewer)
         }
     }
     .responseError { error in
@@ -225,7 +225,7 @@ Add custom request methods by extending `WebService`.
 
 ```
 public extension WebService {
-    
+
     public func fetchBrewers(state state: String) -> ServiceTask {
         return GET("/brewers").setParameters(["state" : name])
     }
@@ -238,13 +238,13 @@ The chainable service task API makes it easy to create custom response handlers 
 extension ServiceTask {
 
     func responseAsBrewers(handler: ([Brewer]) -> Void) -> Self {
-        return 
-            responseJSON { json in
+        return
+            responseJSON { json, response in
               if let models: [Brewer] = JSONDecoder<Brewer>.decode(json)  {
                   return .Value(models)
               } else {
                 // any value conforming to ErrorType
-                return .Failure(JSONDecoderError.FailedToDecodeBrewer) 
+                return .Failure(JSONDecoderError.FailedToDecodeBrewer)
               }
             }
             .updateUI { value in
@@ -274,7 +274,7 @@ service
 
 ### Objective-C Interoperability
 
-ELWebService supports Objective-C via specially-named response handler methods. See the [Objective-C Interoperability section](/docs/Programming-Guide.md#objective-c-interoperability) in the [ELWebService Programming Guide](/docs/Programming-Guide.md) for more information. 
+ELWebService supports Objective-C via specially-named response handler methods. See the [Objective-C Interoperability section](/docs/Programming-Guide.md#objective-c-interoperability) in the [ELWebService Programming Guide](/docs/Programming-Guide.md) for more information.
 
 ```
 extension ServiceTask {
@@ -282,7 +282,7 @@ extension ServiceTask {
 
     @objc public func responseObjC(handler: (NSData?, NSURLResponse?) -> ObjCHandlerResult?) -> Self
 
-    @objc public func responseJSONObjC(handler: (AnyObject) -> ObjCHandlerResult?) -> Self
+    @objc public func responseJSONObjC(handler: (AnyObject, NSURLResponse?) -> ObjCHandlerResult?) -> Self
 
     @objc public func responseErrorObjC(handler: (NSError) -> Void) -> Self
 

--- a/Source/Core/ServiceTask+ObjC.swift
+++ b/Source/Core/ServiceTask+ObjC.swift
@@ -93,9 +93,9 @@ extension ServiceTask {
      - parameter handler: Response handler to execute upon receiving a response.
      - returns: Self instance to support chaining.
      */
-    @objc public func responseJSONObjC(handler: (AnyObject) -> ObjCHandlerResult?) -> Self {
-        return responseJSON { json in
-            return ServiceTaskResult(objCHandlerResult: handler(json))
+    @objc public func responseJSONObjC(handler: (AnyObject, NSURLResponse?) -> ObjCHandlerResult?) -> Self {
+        return responseJSON { json, response in
+            return ServiceTaskResult(objCHandlerResult: handler(json, response))
         }
     }
     

--- a/Source/Core/ServiceTask.swift
+++ b/Source/Core/ServiceTask.swift
@@ -252,7 +252,7 @@ extension ServiceTask {
 
 extension ServiceTask {
     /// A closure type alias for handling the response as JSON.
-    public typealias JSONHandler = (AnyObject) -> ServiceTaskResult
+    public typealias JSONHandler = (AnyObject, NSURLResponse?) -> ServiceTaskResult
     
     /**
      Add a response handler to serialize the response body as a JSON object. The
@@ -266,7 +266,7 @@ extension ServiceTask {
             if let data = data {
                 do {
                     let json = try NSJSONSerialization.JSONObjectWithData(data, options: NSJSONReadingOptions.AllowFragments)
-                    return handler(json)
+                    return handler(json, response)
                 } catch let jsonError as NSError {
                     return .Failure(jsonError)
                 } catch {

--- a/docs/Programming-Guide.md
+++ b/docs/Programming-Guide.md
@@ -2,7 +2,7 @@
 
 ## About ELWebService
 
-[ELWebService](https://github.com/Electrode-iOS/ELWebService) is a lightweight HTTP networking framework written in Swift. ELWebService simplifies interaction with HTTP web services by providing a concise API for encoding a `NSURLRequest` object and processing the resulting `NSURLResponse`. 
+[ELWebService](https://github.com/Electrode-iOS/ELWebService) is a lightweight HTTP networking framework written in Swift. ELWebService simplifies interaction with HTTP web services by providing a concise API for encoding a `NSURLRequest` object and processing the resulting `NSURLResponse`.
 
 Unlike many other iOS networking libraries, ELWebService is not a wrapper around `NSURLSession` or `NSURLConnection`. Instead ELWebService is designed to be unobtrusive by acting as a convenience for working with request and response objects while leaving the crucial implementation details of the various session delegate methods up to the developer.
 
@@ -18,7 +18,7 @@ By conforming to `SessionDataTaskDataSource`, your code has complete control ove
 
 ```
 struct MyDataTaskDataSource: SessionDataTaskDataSource {
-    func dataTaskWithRequest(request: NSURLRequest, 
+    func dataTaskWithRequest(request: NSURLRequest,
                           completion: (NSData?, NSURLResponse?, NSError?) -> Void) -> NSURLSessionDataTask? {
         return NSURLSession.sharedSession().dataTaskWithRequest(request, completionHandler: completion);
     }
@@ -87,7 +87,7 @@ Use the `responseJSON()` method to add a closure for handling the response as se
 ```
 brewClient
     .GET("/brewers")
-    .responseJSON { json: AnyObject? in
+    .responseJSON { json: AnyObject?, response: NSURLResponse? in
         // process JSON
     }
     .responseError { error in
@@ -103,12 +103,12 @@ All response and error handlers that are registered with the `response()`, `resp
 ```
 service
     .GET("/brewers")
-    .responseJSON { json in
+    .responseJSON { json, response in
       if let models: [Brewer] = JSONDecoder<Brewer>.decode(json)  {
           return .Value(models)
       } else {
         // any value conforming to ErrorType
-        return .Failure(JSONDecoderError.FailedToDecodeBrewer) 
+        return .Failure(JSONDecoderError.FailedToDecodeBrewer)
       }
     }
     .updateUI { value in
@@ -140,7 +140,7 @@ brewClient
     .setParameters(["name": "Trashboat Brewing"])
 ```
 
-The code above produces a request with the body contents set to `"name=Trashboat%20Brewing"`. 
+The code above produces a request with the body contents set to `"name=Trashboat%20Brewing"`.
 
 JSON can be sent by specifying the parameter encoding to be `.JSON`.
 
@@ -169,7 +169,7 @@ brewClient
     .setCachePolicy(.ReloadIgnoringLocalCacheData)
 ```
 
-Rather than providing a request-encoding API as an object that is directly mutated and passed around (ex: `NSURLRequest`), ELWebService offers a fixed set of methods to centralize and encapsulate the intended mutations that are made to the request value. 
+Rather than providing a request-encoding API as an object that is directly mutated and passed around (ex: `NSURLRequest`), ELWebService offers a fixed set of methods to centralize and encapsulate the intended mutations that are made to the request value.
 
 
 #### `setHeaderValue`
@@ -230,7 +230,7 @@ The example below uses `ServiceTaskResult` to first filter out any responses tha
 
 The second response handler in the example serializes the response a JSON and attempts to decode the JSON as an array of model values. If the decoding succeeds the handler uses the `.Value` result to pass the model values to handler registered by `updateUI()`. In the case of a failure a `.Failure` result is returned with a decoding error.
 
-Finally the `updateUI()` handler will be run if all previous response handlers did not return a `.Failure` result. The update UI handler is passed the value that was returned from the last response handler in the chain via a `.Value` result. 
+Finally the `updateUI()` handler will be run if all previous response handlers did not return a `.Failure` result. The update UI handler is passed the value that was returned from the last response handler in the chain via a `.Value` result.
 
 ```
 service
@@ -238,14 +238,14 @@ service
     .response { data, response in
         // filter reseponses that do not respond with status 200
 
-        if let httpResponse = response as? NSHTTPURLResponse 
+        if let httpResponse = response as? NSHTTPURLResponse
             where httpResponse.statusCode != 200 {
             return .Failure(ResponseError.ExpectedStatus200)
         }
 
         return .Empty
     }
-    .responseJSON { json in
+    .responseJSON { json, response in
         // decode JSON as an array of models
 
         if let models: [Brewer] = JSONDecoder<Brewer>.decode(json)  {
@@ -253,7 +253,7 @@ service
             return .Value(models)
         } else {
             // any value conforming to ErrorType
-            return .Failure(JSONDecoderError.FailedToDecodeBrewer) 
+            return .Failure(JSONDecoderError.FailedToDecodeBrewer)
         }
     }
     .updateUI { (value: Any) in
@@ -306,13 +306,13 @@ Along with request methods it would be nice to have response handler methods tha
 extension ServiceTask {
 
     func responseAsBrewers(handler: ([Brewer]) -> Void) -> Self {
-        return 
-            responseJSON { json in
+        return
+            responseJSON { json, response in
               if let models: [Brewer] = JSONDecoder<Brewer>.decode(json)  {
                   return .Value(models)
               } else {
                 // any value conforming to ErrorType
-                return .Failure(JSONDecoderError.FailedToDecodeBrewer) 
+                return .Failure(JSONDecoderError.FailedToDecodeBrewer)
               }
             }
             .updateUI { value in
@@ -354,29 +354,29 @@ To work around this limitation a special `ServiceTask` request API is provided f
 extension ServiceTask {
     /**
      Set request parameter values and configure them to be JSON-encoded.
-     
+
      This method is designed to only be called from Obj-C. Please use
      `setParameters(parameters: [String: AnyObject], encoding: Request.ParameterEncoding)`
      when calling from Swift.
-     
+
      - parameter parameters: Request parameter values.
     */
     @objc public func setJSONEncodedParametersObjC(parameters: [String : AnyObject]) -> Self
 
     /**
      Set request parameter values and configure them to be Percent-encoded.
-     
+
      This method is designed to be called from Obj-C only. Please use
      `setParameters(parameters: [String: AnyObject], encoding: Request.ParameterEncoding)`
      when calling from Swift.
-     
+
      - parameter parameters: Request parameter values.
     */
     @objc public func setPercentEncodedParametersObjC(parameters: [String : AnyObject]) -> Self
 
     /**
      Configure the request parameters to be JSON-encoded.
-    
+
      This method is designed to be called from Obj-C only. Please use
      `setParameterEncoding(encoding: .JSON)` when calling
      from Swift.
@@ -385,7 +385,7 @@ extension ServiceTask {
 
     /**
      Configure the request parameters to be Percent-encoded.
-     
+
      This method is designed to be called from Obj-C only. Please use
      `setParameterEncoding(encoding: .Percent)` when calling
      from Swift.
@@ -406,7 +406,7 @@ extension ServiceTask {
 
     @objc public func responseObjC(handler: (NSData?, NSURLResponse?) -> ObjCHandlerResult?) -> Self
 
-    @objc public func responseJSONObjC(handler: (AnyObject) -> ObjCHandlerResult?) -> Self
+    @objc public func responseJSONObjC(handler: (AnyObject, NSURLResponse?) -> ObjCHandlerResult?) -> Self
 
     @objc public func responseErrorObjC(handler: (NSError) -> Void) -> Self
 
@@ -425,13 +425,13 @@ The syntax when using the Swift API looks like:
 var client = WebService(baseURLString: "https://somehapi.herokuapp.com")
 let task = service.GET("/brewers")
 
-task.responseJSON { json in
+task.responseJSON { json, response in
       if let models: [Brewer] = JSONDecoder<Brewer>.decode(json)  {
           // pass encoded value via ServiceTaskResult
           return .Value(models)
       } else {
         // any value conforming to ErrorType
-        return .Failure(JSONDecoderError.FailedToDecodeBrewer) 
+        return .Failure(JSONDecoderError.FailedToDecodeBrewer)
       }
     }
     .updateUI { value in
@@ -449,13 +449,13 @@ In Objective-C the above Swift example translates into this:
 WebService *service = [[WebService alloc] initWithBaseURLString:@"https://somehapi.herokuapp.com"];
 ServiceTask *task = [service GET:@"/brewers"];
 
-[task responseJSON:^HandlerResult *(id json) {
+[task responseJSON:^HandlerResult *(id json, NSURLResponse *response) {
     NSArray *models = [JSONDecoder decodeBrewersFromJSON:json];
 
     if (models != nil) {
         // return result values with `ObjCHandlerResult` instead of `ServiceTaskResult
         return [ObjCHandlerResult resultWithValue:models];
-        
+
     } else {
         NSError *error
         return [ObjCHandlerResult resultWithError:error];


### PR DESCRIPTION
Sometimes the JSON response needs to be evaluated based on an `NSHTTPURLResponse` status code. Passing in `NSURLResponse` allows for this.