### PR TITLE
Add result processing handlers to `ServiceTask`

### DIFF
--- a/ELWebServiceTests/ServiceTaskTests.swift
+++ b/ELWebServiceTests/ServiceTaskTests.swift
@@ -317,6 +317,261 @@ extension ServiceTaskTests {
     }
 }
 
+// MARK: - Transform
+
+extension ServiceTaskTests {
+    func test_transform_closureCalled() {
+        let closureCalled = expectationWithDescription("transform closure called")
+
+        successfulTask()
+            .transform { _ in
+                closureCalled.fulfill()
+                return .Empty
+            }
+            .resume()
+
+        waitForExpectationsWithTimeout(2, handler: nil)
+    }
+
+    func test_transform_closureNotCalledForError() {
+        let done = expectationWithDescription("done")
+
+        errorTask()
+            .transform { _ in
+                XCTFail("Did not expect transform closure to be called")
+                return .Empty
+            }
+            .updateErrorUI { _ in
+                done.fulfill()
+            }
+            .resume()
+
+        waitForExpectationsWithTimeout(2, handler: nil)
+    }
+
+    func test_transform_ordering() {
+        let closure1Called = expectationWithDescription("transform closure 1 called")
+        let closure2Called = expectationWithDescription("transform closure 2 called")
+        var closure1CalledFirst = false
+
+        successfulTask()
+            .transform { _ in
+                closure1CalledFirst = true
+                closure1Called.fulfill()
+                return .Empty
+            }
+            .transform { _ in
+                XCTAssertTrue(closure1CalledFirst, "Expected closure 1 to be called before closure 2")
+                closure2Called.fulfill()
+                return .Empty
+            }
+            .resume()
+
+        waitForExpectationsWithTimeout(2, handler: nil)
+    }
+
+    func test_transform_resultPropagation() {
+        let closure1Called = expectationWithDescription("transform closure 1 called")
+        let closure2Called = expectationWithDescription("transform closure 2 called")
+        let closure3Called = expectationWithDescription("transform closure 3 called")
+        let closure4Called = expectationWithDescription("transform closure 4 called")
+        let done = expectationWithDescription("done")
+
+        successfulTask()
+            .transform { value in
+                XCTAssertNil(value, "Expected initial value to be nil")
+
+                closure1Called.fulfill()
+                return .Value("transform 1 value")
+            }
+            .response { _, _ in
+                return .Value("response value")
+            }
+            .transform { value in
+                if let value = value as? String {
+                    XCTAssertEqual(value, "response value", "Expected to receive result of response handler")
+                } else {
+                    XCTFail("Expected to receive result of previous handler")
+                }
+
+                closure2Called.fulfill()
+                return .Value("transform 2 value")
+            }
+            .transform { value in
+                if let value = value as? String {
+                    XCTAssertEqual(value, "transform 2 value", "Expected to receive result of previous handler")
+                } else {
+                    XCTFail("Expected to receive result of previous handler")
+                }
+
+                closure3Called.fulfill()
+                return .Empty
+            }
+            .transform { value in
+                XCTAssertNil(value, "Expected .Empty result to propagate as nil")
+
+                closure4Called.fulfill()
+                return .Value("transform 4 value")
+            }
+            .updateUI { value in
+                if let value = value as? String {
+                    XCTAssertEqual(value, "transform 4 value", "Expected to receive result of previous handler")
+                } else {
+                    XCTFail("Expected to receive result of previous handler")
+                }
+
+                done.fulfill()
+            }
+            .resume()
+
+        waitForExpectationsWithTimeout(2, handler: nil)
+    }
+}
+
+// MARK: - Recover
+
+extension ServiceTaskTests {
+    func test_recover_closureCalled() {
+        let closureCalled = expectationWithDescription("closure called")
+
+        errorTask()
+            .recover { error in
+                closureCalled.fulfill()
+                return .Failure(error)
+            }
+            .resume()
+
+        waitForExpectationsWithTimeout(2, handler: nil)
+    }
+
+    func test_recover_closureNotCalledForSuccess() {
+        let done = expectationWithDescription("done")
+
+        successfulTask()
+            .recover { error in
+                XCTFail("Did not expect recover closure to be called")
+                return .Failure(error)
+            }
+            .updateUI { _ in
+                done.fulfill()
+            }
+            .resume()
+
+        waitForExpectationsWithTimeout(2, handler: nil)
+    }
+
+    func test_recover_ordering() {
+        let closure1Called = expectationWithDescription("recover closure 1 callled")
+        let closure2Called = expectationWithDescription("recover closure 2 callled")
+        var closure1CalledFirst = false
+
+        errorTask()
+            .recover { error in
+                closure1CalledFirst = true
+                closure1Called.fulfill()
+                return .Failure(error)
+            }
+            .recover { error in
+                XCTAssertTrue(closure1CalledFirst, "Expected closure 1 to be called before closure 2")
+                closure2Called.fulfill()
+                return .Failure(error)
+            }
+            .resume()
+
+        waitForExpectationsWithTimeout(2, handler: nil)
+    }
+
+    func test_recover_resultPropagation() {
+        let closure1Called = expectationWithDescription("recover closure 1 callled")
+        let closure2Called = expectationWithDescription("recover closure 2 callled")
+        let closure3Called = expectationWithDescription("recover closure 3 callled")
+        let done = expectationWithDescription("done")
+
+        enum ServiceTaskTestError: ErrorType {
+            case Oops(detail: String)
+        }
+
+        errorTask()
+            .recover { error in
+                closure1Called.fulfill()
+                return .Failure(error)
+            }
+            .recover { error in
+                closure2Called.fulfill()
+                return .Failure(ServiceTaskTestError.Oops(detail: "closure 2 error"))
+            }
+            .recover { error in
+                if let error = error as? ServiceTaskTestError {
+                    switch error {
+                    case .Oops(let detail):
+                        XCTAssertEqual(detail, "closure 2 error", "Expected to receive result of previous handler")
+                    }
+                } else {
+                    XCTFail("Expected to receive result of previous handler")
+                }
+
+                closure3Called.fulfill()
+                return .Failure(ServiceTaskTestError.Oops(detail: "closure 3 error"))
+            }
+            .updateErrorUI { error in
+                if let error = error as? ServiceTaskTestError {
+                    switch error {
+                    case .Oops(let detail):
+                        XCTAssertEqual(detail, "closure 3 error", "Expected to receive result of previous handler")
+                    }
+                } else {
+                    XCTFail("Expected to receive result of previous handler")
+                }
+
+                done.fulfill()
+            }
+            .resume()
+        
+        waitForExpectationsWithTimeout(2, handler: nil)
+    }
+}
+
+// MARK: - Transform and Recover Control Flow
+
+extension ServiceTaskTests {
+    func test_transformAndRecover_controlFlow() {
+        let closure1Called = expectationWithDescription("recover closure 1 callled")
+        let closure3Called = expectationWithDescription("recover closure 3 callled")
+        let done = expectationWithDescription("done")
+
+        enum ServiceTaskTestError: ErrorType {
+            case Oops
+        }
+
+        successfulTask()
+            .transform { _ in
+                closure1Called.fulfill()
+                return .Failure(ServiceTaskTestError.Oops)
+            }
+            .transform { _ in
+                XCTFail("Did not expect transform closure to be called after failure")
+                return .Empty
+            }
+            .recover { _ in
+                closure3Called.fulfill()
+                return .Value("closure 3 value")
+            }
+            .recover { error in
+                XCTFail("Did not expect recover closure to be called after recovery")
+                return .Failure(error)
+            }
+            .updateErrorUI { _ in
+                XCTFail("Did not expect update UI (error) closure to be called after recovery")
+            }
+            .updateUI { _ in
+                done.fulfill()
+            }
+            .resume()
+
+        waitForExpectationsWithTimeout(2, handler: nil)
+    }
+}
+
 // MARK: - Request API
 
 extension ServiceTaskTests {

--- a/Source/Core/ServiceTask+ObjC.swift
+++ b/Source/Core/ServiceTask+ObjC.swift
@@ -67,12 +67,6 @@ extension ServiceTask {
 // MARK: - Obj-C Interop for Response Handler API
 
 extension ServiceTask {
-    public enum ObjCBridgeError: ErrorType {
-        /// An error indicating an objc handler should have been called, but the
-        /// value was neither `nil`, nor an object.
-        case NonObjectValue
-    }
-    
     /// Response handler type for Obj-C
     typealias ObjCResponseHandler = (NSData?, NSURLResponse?) -> ObjCHandlerResult?
 
@@ -121,11 +115,7 @@ extension ServiceTask {
      */
     @objc public func transformObjC(handler: (AnyObject?) -> ObjCHandlerResult?) -> Self {
         return transform { value in
-            guard let value = value as? AnyObject? else {
-                return .Failure(ObjCBridgeError.NonObjectValue)
-            }
-
-            return ServiceTaskResult(objCHandlerResult: handler(value))
+            return ServiceTaskResult(objCHandlerResult: handler(value as! AnyObject?))
         }
     }
 

--- a/Source/Core/ServiceTask+ObjC.swift
+++ b/Source/Core/ServiceTask+ObjC.swift
@@ -67,6 +67,7 @@ extension ServiceTask {
 // MARK: - Obj-C Interop for Response Handler API
 
 extension ServiceTask {
+    
     /// Response handler type for Obj-C
     typealias ObjCResponseHandler = (NSData?, NSURLResponse?) -> ObjCHandlerResult?
 

--- a/Source/Core/ServiceTask.swift
+++ b/Source/Core/ServiceTask.swift
@@ -190,6 +190,9 @@ extension ServiceTask {
 // MARK: - Response API
 
 extension ServiceTask {
+    /// A closure type alias for a result transformation handler.
+    public typealias ResultTransformer = Any? -> ServiceTaskResult
+
     /**
      Add a response handler to be called on background thread after a successful
      response has been received.
@@ -212,6 +215,37 @@ extension ServiceTask {
         return self
     }
     
+    /**
+     Add a response handler to transform a (non-error) result produced by an earlier
+     response handler.
+
+     The handler can return any type of service task result, `.Empty`, `.Value` or
+     `.Error`. The result is propagated to later response handlers.
+
+     - parameter handler: Transformation handler to execute.
+     - returns: Self instance to support chaining.
+     */
+    public func transform(handler: ResultTransformer) -> Self {
+        handlerQueue.addOperationWithBlock {
+            guard let taskResult = self.taskResult else {
+                return
+            }
+
+            switch taskResult {
+            case .Failure(_):
+                return // bail out; do not run this handler
+
+            case .Empty:
+                self.taskResult = handler(nil)
+
+            case .Value(let value):
+                self.taskResult = handler(value)
+            }
+        }
+        
+        return self
+    }
+
     /**
      Add a handler that runs on the main thread and is responsible for updating 
      the UI with a given value. The handler is only called if a previous response 
@@ -280,6 +314,9 @@ extension ServiceTask {
 // MARK: - Error Handling
 
 extension ServiceTask {
+    /// A closure type alias for an error-recovery handler.
+    public typealias ErrorRecoveryHandler = ErrorType -> ServiceTaskResult
+
     /**
     Add a response handler to be called if a request results in an error.
     
@@ -316,6 +353,35 @@ extension ServiceTask {
                     }
                 case .Empty, .Value(_): break
                 }
+            }
+        }
+        
+        return self
+    }
+
+    /**
+     Add a response handler to recover from an error produced by an earlier response
+     handler.
+     
+     The handler can return either a `.Value` or `.Empty`, indicating it was able to
+     recover from the error, or an `.Error`, indicating that it was not able to
+     recover. The result is propagated to later response handlers.
+     
+     - parameter handler: Recovery handler to execute when an error occurs.
+     - returns: Self instance to support chaining.
+    */
+    public func recover(handler: ErrorRecoveryHandler) -> Self {
+        handlerQueue.addOperationWithBlock {
+            guard let taskResult = self.taskResult else {
+                return
+            }
+
+            switch taskResult {
+            case .Failure(let error):
+                self.taskResult = handler(error)
+
+            case .Empty, .Value(_):
+                return // bail out; do not run this handler
             }
         }
         

--- a/Source/Core/ServiceTask.swift
+++ b/Source/Core/ServiceTask.swift
@@ -227,9 +227,7 @@ extension ServiceTask {
      */
     public func transform(handler: ResultTransformer) -> Self {
         handlerQueue.addOperationWithBlock {
-            guard let taskResult = self.taskResult else {
-                return
-            }
+            let taskResult = self.taskResult ?? .Empty
 
             switch taskResult {
             case .Failure(_):

--- a/Source/Core/ServiceTask.swift
+++ b/Source/Core/ServiceTask.swift
@@ -227,7 +227,9 @@ extension ServiceTask {
      */
     public func transform(handler: ResultTransformer) -> Self {
         handlerQueue.addOperationWithBlock {
-            let taskResult = self.taskResult ?? .Empty
+            guard let taskResult = self.taskResult else {
+                return
+            }
 
             switch taskResult {
             case .Failure(_):

--- a/Source/Core/ServiceTask.swift
+++ b/Source/Core/ServiceTask.swift
@@ -220,7 +220,7 @@ extension ServiceTask {
      response handler.
 
      The handler can return any type of service task result, `.Empty`, `.Value` or
-     `.Error`. The result is propagated to later response handlers.
+     `.Failure`. The result is propagated to later response handlers.
 
      - parameter handler: Transformation handler to execute.
      - returns: Self instance to support chaining.
@@ -364,7 +364,7 @@ extension ServiceTask {
      handler.
      
      The handler can return either a `.Value` or `.Empty`, indicating it was able to
-     recover from the error, or an `.Error`, indicating that it was not able to
+     recover from the error, or an `.Failure`, indicating that it was not able to
      recover. The result is propagated to later response handlers.
      
      - parameter handler: Recovery handler to execute when an error occurs.

--- a/docs/Programming-Guide.md
+++ b/docs/Programming-Guide.md
@@ -107,9 +107,75 @@ service
     .resume()
 ```
 
+### Composing Response Closures
+
+At times, it can be useful to process the response using multiple closures. Additional processing closures are added using the `transform()` method.
+
+```
+service
+    .GET("/brewers")
+    .response { data, response in
+        let intermediateValue: (Int, Int)
+
+        // process response to create intermediate value
+
+        return .Value(intermediateValue)
+    }
+    .transform { _intermediateValue in
+        let intermediateValue = _intermediateValue as! (Int, Int)
+        let finalValue: Int
+
+        // process intermediate value to create final value
+
+        return .Value(finalValue)
+    }
+    .resume()
+```
+
+Processing closures are only called when there is a value to process, not when there is an error. If an earlier closure returns a `.Failure` result, then the closures that follow are not invoked.
+
+```
+service
+    .GET("/brewers")
+    .response { data, response in
+        return .Failure(Error.Nope)
+    }
+    .transform { value in
+        // closure is **not** called
+    }
+    .resume()
+```
+
+Closures that _are_ called when there is an error can be added using the `recover()` method.
+
+A recovery closure can return a value (`.Empty` or `.Value`) to indicate that it succeeded in recovering. Or, it can return an error (`.Failure`) to indicate that it could not recover.
+
+```
+service
+    .GET("/brewers")
+    .response { data, response in
+        return .Failure(MyError.Nope)
+    }
+    .recover { error in
+        if recoverGracefully(error) {
+            // recovery succeeds:
+            return .Value("It's all good")
+        }
+
+        // recovery fails:
+        return .Failure(error)
+    }
+    .transform { value in
+        // closure **is** called _if_ recovery succeeds
+    }
+    .resume()
+```
+
+Any number of processing closures can be added. Closures are called in the order that they are added, with the result of one closure becoming the input to the next. Control switches between transform and recovery closures as values and errors are returned.
+
 ## Updating UI
 
-All response and error handlers that are registered with the `response()`, `responseJSON()`, and `responseError()` methods will run on a background queue. If you're updating UI with a response or error you'll need to make sure your updates happen on the main thread. ELWebService provides `updateUI()` and `updateErrorUI()` methods for registering handlers that will be dispatched to the main queue.
+All response and error handlers that are registered with the `response()`, `responseJSON()`, `responseError()`, `transform()` and `recover()` methods will run on a background queue. If you're updating UI with a response or error you'll need to make sure your updates happen on the main thread. ELWebService provides `updateUI()` and `updateErrorUI()` methods for registering handlers that will be dispatched to the main queue.
 
 ```
 service

--- a/docs/Programming-Guide.md
+++ b/docs/Programming-Guide.md
@@ -181,12 +181,12 @@ All response and error handlers that are registered with the `response()`, `resp
 service
     .GET("/brewers")
     .responseJSON { json, response in
-      if let models: [Brewer] = JSONDecoder<Brewer>.decode(json)  {
-          return .Value(models)
-      } else {
-        // any value conforming to ErrorType
-        return .Failure(JSONDecoderError.FailedToDecodeBrewer)
-      }
+        if let models: [Brewer] = JSONDecoder<Brewer>.decode(json)  {
+            return .Value(models)
+        } else {
+            // any value conforming to ErrorType
+            return .Failure(JSONDecoderError.FailedToDecodeBrewer)
+        }
     }
     .updateUI { value in
         // this closure will be dispatched to the main queue via `updateUI()`
@@ -200,7 +200,7 @@ service
 
 ## Request Parameters
 
-Parameterized data that is structured as a dictinoary type of `[String: AnyObject]` can be sent in the request with the `setParameters()` method. Parameters are percent encoded and appended as a query string of the request URL for GET and HEAD requests. The code below sends a request with the URL "/brewers?state=new%20york".
+Parameterized data that is structured as a dictionary type of `[String: AnyObject]` can be sent in the request with the `setParameters()` method. Parameters are percent encoded and appended as a query string of the request URL for GET and HEAD requests. The code below sends a request with the URL "/brewers?state=new%20york".
 
 ```
 service
@@ -299,7 +299,7 @@ Finally the `updateUI()` handler will be run if all previous response handlers d
 service
     .GET("/brewers")
     .response { data, response in
-        // filter reseponses that do not respond with status 200
+        // filter responses that do not have status 200
 
         if let httpResponse = response as? NSHTTPURLResponse
             where httpResponse.statusCode != 200 {


### PR DESCRIPTION
**Note:** This PR isn't ready to be merged (no tests, for example), but I thought it would make a good starting place for discussing whether this functionality should be added to the service task API.

#### What does this PR do?

Basically, it's a lightweight Promise-style API for the service task…

I added two new methods to the `ServiceTask` class:

- `transform()` is analogous to `Promise.then()`. It is only called if the current result _is not_ a `.Failure`. It takes the current **value** (or `nil`) and returns a new result.
- `recover()` is analogous to `Promise.catch()`. It is only called if the current result _is_ a `.Failure`. It takes the current **error** and returns a new result.

In either case, the new result can be `.Empty`, `.Value` or `.Failure` and it is used for all future handlers.

#### Any background context you want to provide?

Sometimes it makes sense to split your response processing into a series of handlers, rather than a single handler. Currently there is no way for a handler to access the result of previous handlers; it can only start "from scratch" with the response payload.