### PR TITLE
force-downcast `updateUIObjC` handler's value to avoid silent failure.

### DIFF
--- a/ELWebServiceTests/ObjCInteropTests.m
+++ b/ELWebServiceTests/ObjCInteropTests.m
@@ -63,6 +63,23 @@
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
 }
 
+- (void)test_updateUIObjC_calledWhenHandlerResultIsNil {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"updateUI handler is called"];
+    WebService *service = [[WebService alloc] initWithBaseURLString:@"foo"];
+    ServiceTask *task = [service GET:@"bar"];
+    [task responseObjC:^ObjCHandlerResult *(NSData *data, NSURLResponse *response) {
+        return nil;
+    }];
+    
+    [task updateUIObjC:^(id value) {
+        [expectation fulfill];
+    }];
+    
+    [task injectResponse:[self mockResponse] data:nil error:nil];
+    
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
+}
+
 - (void)test_responseJSONObjC_receivesHandlerResult {
     XCTestExpectation *expectation = [self expectationWithDescription:@"updateUI handler is called"];
     WebService *service = [[WebService alloc] initWithBaseURLString:@"foo"];

--- a/Source/Core/ServiceTask+ObjC.swift
+++ b/Source/Core/ServiceTask+ObjC.swift
@@ -132,9 +132,7 @@ extension ServiceTask {
     */
     @objc public func updateUIObjC(handler: (AnyObject?) -> Void) -> Self {
         return updateUI { value in
-            if let value = value as? AnyObject {
-                handler(value)
-            }
+            handler(value as! AnyObject?)
         }
     }
     


### PR DESCRIPTION
Fixes #34.