### PR TITLE
Fix HEAD and DELETE parameter encoding

### DIFF
--- a/ELWebServiceTests/RequestTests.swift
+++ b/ELWebServiceTests/RequestTests.swift
@@ -160,4 +160,35 @@ class RequestTests: XCTestCase {
         XCTAssertEqual(components.count, 1)
         XCTAssertEqual(encodedBody, testData)
     }
+
+    // MARK: - Where do parameters go?
+
+    func test_urlRequestValue_parametersInURL() {
+        test_urlRequestValue_parametersInURL(.GET)
+        test_urlRequestValue_parametersInURL(.HEAD)
+        test_urlRequestValue_parametersInURL(.DELETE)
+    }
+
+    func test_urlRequestValue_parametersInURL(method: Request.Method) {
+        var request = Request(method, url: "http://httpbin.org/")
+        request.parameters = ["x" : "1"]
+
+        let query = request.urlRequestValue.URL!.query!
+
+        XCTAssertEqual(query, "x=1")
+    }
+
+    func test_urlRequestValue_parametersInBody() {
+        test_urlRequestValue_parametersInBody(.PUT)
+        test_urlRequestValue_parametersInBody(.POST)
+    }
+
+    func test_urlRequestValue_parametersInBody(method: Request.Method) {
+        var request = Request(method, url: "http://httpbin.org/")
+        request.parameters = ["x" : "1"]
+
+        let body = NSString(data: request.urlRequestValue.HTTPBody!, encoding: NSUTF8StringEncoding)
+
+        XCTAssertEqual(body, "x=1")
+    }
 }

--- a/Source/Core/Request.swift
+++ b/Source/Core/Request.swift
@@ -31,6 +31,21 @@ public struct Request {
         case POST = "POST"
         case PUT = "PUT"
         case DELETE = "DELETE"
+
+        /**
+         Whether requests using this method should encode parameters in the URL, instead of the body.
+
+         `GET`, `HEAD` and `DELETE` requests encode parameters in the URL, `PUT` and `POST` encode
+         them in the body.
+         */
+        func encodesParametersInURL() -> Bool {
+            switch self {
+            case .GET, .HEAD, .DELETE:
+                return true
+            default:
+                return false
+            }
+        }
     }
     
     // MARK: Parameter Encodings
@@ -166,13 +181,12 @@ extension Request: URLRequestEncodable {
         }
         
         if parameters.count > 0 {
-            switch method {
-            case .GET, .HEAD, .DELETE:
+            if method.encodesParametersInURL() {
                 if let url = urlRequest.URL,
                     encodedURL = parameterEncoding.encodeURL(url, parameters: parameters) {
                         urlRequest.URL = encodedURL
                 }
-            default:
+            } else {
                 if let data = parameterEncoding.encodeBody(parameters) {
                     urlRequest.HTTPBody = data
                     

--- a/Source/Core/Request.swift
+++ b/Source/Core/Request.swift
@@ -167,7 +167,7 @@ extension Request: URLRequestEncodable {
         
         if parameters.count > 0 {
             switch method {
-            case .GET, .HEAD:
+            case .GET, .HEAD, .DELETE:
                 if let url = urlRequest.URL,
                     encodedURL = parameterEncoding.encodeURL(url, parameters: parameters) {
                         urlRequest.URL = encodedURL

--- a/Source/Core/Request.swift
+++ b/Source/Core/Request.swift
@@ -65,9 +65,15 @@ public struct Request {
          - returns: A NSURL value with query string parameters encoded.
         */
         public func encodeURL(url: NSURL, parameters: [String : AnyObject]) -> NSURL? {
-            let components = NSURLComponents(URL: url, resolvingAgainstBaseURL: false)
-            components?.appendQueryItems(parameters.queryItems)
-            return components?.URL
+            switch self {
+            case .Percent:
+                let components = NSURLComponents(URL: url, resolvingAgainstBaseURL: false)
+                components?.appendQueryItems(parameters.queryItems)
+                return components?.URL
+            case .JSON:
+                assertionFailure("Cannot encode URL parameters using JSON encoding")
+                return nil // <-- unreachable
+            }
         }
         
         /**

--- a/Source/Core/Request.swift
+++ b/Source/Core/Request.swift
@@ -167,7 +167,7 @@ extension Request: URLRequestEncodable {
         
         if parameters.count > 0 {
             switch method {
-            case .GET, .DELETE:
+            case .GET, .HEAD:
                 if let url = urlRequest.URL,
                     encodedURL = parameterEncoding.encodeURL(url, parameters: parameters) {
                         urlRequest.URL = encodedURL


### PR DESCRIPTION
#### What does this PR do?

Fixes a discrepancy in how request "parameters" are encoded for `HEAD` and `DELETE` requests.

#### Any background context you want to provide?

According to the [Programming Guide](https://github.com/Electrode-iOS/ELWebService/blob/master/docs/Programming-Guide.md#request-parameters) (emphasis mine):

> Parameters are percent encoded and appended as a query string of the request URL for **GET and HEAD** requests… For **all other** HTTP methods, parameters are sent as the request body.

But, the code was appending parameters to the query string for `GET` and `DELETE` (and _not_ `HEAD`) requests.

I know there's an open issue to change the way parameters work (#40), but it seems like this needs to be corrected, even if these new API are introduced.