### PR TITLE
Add case .Custom to ParameterEncoding

### DIFF
--- a/ELWebServiceTests/ParameterEncodingTests.swift
+++ b/ELWebServiceTests/ParameterEncodingTests.swift
@@ -43,22 +43,49 @@ class ParameterEncodingTests: XCTestCase {
         let components = stringValue.componentsSeparatedByString("=")
         XCTAssertEqual(components[1], "500")
     }
-    
+
     func test_encodeURL_percentEncodesWithBoolValue() {
         let url = NSURL(string: "http://httpbin.org/get")!
         let parameters = ["boolValue" : true]
         let encoding = Request.ParameterEncoding.Percent
-        
+
         let encodedURL = encoding.encodeURL(url, parameters: parameters)
-        
+
         XCTAssertNotNil(encodedURL, "Encoded URL should be not be nil")
         XCTAssertNotNil(encodedURL?.query, "Encoded URL query should be not be nil")
-        
+
         let stringValue = encodedURL!.query!
         let components = stringValue.componentsSeparatedByString("=")
         XCTAssertEqual(components[1], "1")
     }
-    
+
+    func test_encodeURL_custom() {
+        let url = NSURL(string: "http://httpbin.org/get")!
+        let parameters = ["key" : "part1+part2:part3"]
+        let encoding = Request.ParameterEncoding.Custom(transformer: .URL({
+            (url: NSURL, parameters: [String : AnyObject]) -> NSURL? in
+            guard let components = NSURLComponents(URL: url, resolvingAgainstBaseURL: false) else {
+                return nil
+            }
+            components.queryItems = parameters.queryItems
+            guard let encodedQueryString = components.URL?.query else {
+                return nil
+            }
+            let characterSet = NSMutableCharacterSet(charactersInString: "+:")
+            characterSet.invert()
+            components.percentEncodedQuery = encodedQueryString.stringByAddingPercentEncodingWithAllowedCharacters(characterSet)
+            return components.URL
+        }))
+
+        let encodedURL = encoding.encodeURL(url, parameters: parameters)
+
+        XCTAssertNotNil(encodedURL, "Encoded URL should be not be nil")
+        XCTAssertNotNil(encodedURL?.query, "Encoded URL query should be not be nil")
+
+        let stringValue = encodedURL!.query!
+        XCTAssertEqual(stringValue, "key=part1%2Bpart2%3Apart3")
+    }
+
     // MARK: encodeBody
 
     func test_encodeBody_percentEncodesWithSpacesInStrings() {
@@ -92,4 +119,32 @@ class ParameterEncodingTests: XCTestCase {
             XCTFail("Failed to cast JSON as [String : AnyObject]")
         }
     }
+
+    func test_encodeBody_custom() {
+        let parameters = ["key" : "part1+part2:part3"]
+        let encoding = Request.ParameterEncoding.Custom(transformer: .Body({
+            (parameters: [String : AnyObject]) -> NSData? in
+            let url = NSURL(string: "http://httpbin.org/get")!
+            guard let components = NSURLComponents(URL: url, resolvingAgainstBaseURL: false) else {
+                return nil
+            }
+            components.queryItems = parameters.queryItems
+            guard let encodedQueryString = components.URL?.query else {
+                return nil
+            }
+            let characterSet = NSMutableCharacterSet(charactersInString: "+:")
+            characterSet.invert()
+            guard let percentEncodedQuery = encodedQueryString.stringByAddingPercentEncodingWithAllowedCharacters(characterSet) else {
+                return nil
+            }
+            return percentEncodedQuery.dataUsingEncoding(NSUTF8StringEncoding)
+        }, contentType: "sample"))
+        let encodedData = encoding.encodeBody(parameters)
+
+        XCTAssertNotNil(encodedData, "Encoded body should be non-nil")
+
+        let stringValue = NSString(data: encodedData!, encoding: NSUTF8StringEncoding)!
+        XCTAssertEqual(stringValue, "key=part1%2Bpart2%3Apart3")
+    }
+
 }

--- a/ELWebServiceTests/RequestTests.swift
+++ b/ELWebServiceTests/RequestTests.swift
@@ -93,12 +93,24 @@ class RequestTests: XCTestCase {
 
     func test_settingParameterEncodingToJSON_setsContentTypeToJSON() {
         var request = Request(.GET, url: "http://httpbin.org/")
-        
+
         request.parameterEncoding = .JSON
-        
+
         XCTAssertEqual(request.contentType, Request.ContentType.json)
     }
-    
+
+    func test_settingParameterEncodingToCustom_setsContentTypeToSample() {
+        var request = Request(.GET, url: "http://httpbin.org/")
+
+        let expectedContentType = "sample"
+        request.parameterEncoding = .Custom(transformer: .Body({
+            (_) -> NSData? in
+            return nil
+            }, contentType: expectedContentType))
+
+        XCTAssertEqual(request.contentType, expectedContentType)
+    }
+
     func test_setBody_overwritesExistingBodyData() {
         var request = Request(.POST, url: "http://httpbin.org/")
         let parameters = ["percentEncoded" : "this needs percent encoded"]

--- a/Source/Core/Request.swift
+++ b/Source/Core/Request.swift
@@ -67,6 +67,8 @@ public struct Request {
         */
         // TODO: remove this function in 4.0.0
         public func encodeURL(url: NSURL, parameters: [String : AnyObject]) -> NSURL? {
+            print("DBG: encodeURL(\(url), parameters: \(parameters))")
+
             switch self {
             case .Percent:
                 return url.URLByAppendingQueryItems(parameters.queryItems)
@@ -78,7 +80,12 @@ public struct Request {
             case .Custom(let transformer):
                 switch transformer {
                 case .URL(let converter):
-                    return converter(url: url, parameters: parameters)
+                    print("DBG: converter=\(converter)")
+                    print("DBG: url=\(url)")
+                    print("DBG: parameters=\(parameters)")
+                    let result = converter(url: url, parameters: parameters)
+                    print("DBG: result=\(result)")
+                    return result
                 case .Body:
                     assertionFailure("Cannot custom encode URL parameters using ParameterEncodingTransformer.Body")
                     return nil // <-- unreachable

--- a/Source/Core/Request.swift
+++ b/Source/Core/Request.swift
@@ -67,8 +67,6 @@ public struct Request {
         */
         // TODO: remove this function in 4.0.0
         public func encodeURL(url: NSURL, parameters: [String : AnyObject]) -> NSURL? {
-            print("DBG: encodeURL(\(url), parameters: \(parameters))")
-
             switch self {
             case .Percent:
                 return url.URLByAppendingQueryItems(parameters.queryItems)
@@ -80,12 +78,7 @@ public struct Request {
             case .Custom(let transformer):
                 switch transformer {
                 case .URL(let converter):
-                    print("DBG: converter=\(converter)")
-                    print("DBG: url=\(url)")
-                    print("DBG: parameters=\(parameters)")
-                    let result = converter(url: url, parameters: parameters)
-                    print("DBG: result=\(result)")
-                    return result
+                    return converter(url: url, parameters: parameters)
                 case .Body:
                     assertionFailure("Cannot custom encode URL parameters using ParameterEncodingTransformer.Body")
                     return nil // <-- unreachable


### PR DESCRIPTION
We needed to be able to provide a custom encoding of URL parameters to satisfy our eccentric services requirement.  I works with parameters on URL and in the body.

I also saw that the ParameterEncoding encodeURL function was never used, so I changed that as well (since there was no point to adding .Custom for my URL parameters if I didn't :) )