### PR TITLE
Use URL as base URL rather than String

### DIFF
--- a/ELWebServiceTests/WebServiceTests.swift
+++ b/ELWebServiceTests/WebServiceTests.swift
@@ -103,6 +103,14 @@ class WebServiceTests: XCTestCase {
 
 extension WebServiceTests {
 
+    func test_absoluteURLString_constructsValidURLWhenPathIsAbsoluteURL() {
+        let service = WebService(baseURLString: "http://www.walmart.com/")
+
+        let url = service.absoluteURLString("http://httpbin.org/get")
+
+        XCTAssertEqual(url, "http://httpbin.org/get")
+    }
+
     func test_absoluteURLString_emptyBase() {
         let service = WebService(baseURLString: "")
 
@@ -123,9 +131,9 @@ extension WebServiceTests {
         let service = WebService(baseURLString: "http://www.walmart.com")
 
         // When the relative URL has a scheme, should replace the entire base URL
-        let url = service.absoluteURLString("http://www.amazon.com")
+        let url = service.absoluteURLString("http://httpbin.org")
 
-        XCTAssertEqual(url, "http://www.amazon.com")
+        XCTAssertEqual(url, "http://httpbin.org")
     }
 
     func test_absoluteURLString_baseNoTrailingSlash_relativeNoLeadingSlash() {

--- a/ELWebServiceTests/WebServiceTests.swift
+++ b/ELWebServiceTests/WebServiceTests.swift
@@ -17,16 +17,16 @@ class WebServiceTests: XCTestCase {
         let service = WebService(baseURLString:  "http://httpbin.org/")
         let session = RequestRecordingSession()
         service.session = session
-        
+
         let task = service.GET("/get")
         task.resume()
-        
+
         let recordedRequest = session.recordedRequests.first?.urlRequestValue
         XCTAssertNotNil(recordedRequest)
-        
+
         let method = recordedRequest?.httpMethod
         XCTAssertNotNil(method)
-        
+
         XCTAssertEqual(method!, "GET")
     }
 
@@ -34,67 +34,67 @@ class WebServiceTests: XCTestCase {
         let service = WebService(baseURLString:  "http://httpbin.org/")
         let session = RequestRecordingSession()
         service.session = session
-        
+
         let task = service.POST("/post")
         task.resume()
-        
+
         let recordedRequest = session.recordedRequests.first?.urlRequestValue
         XCTAssertNotNil(recordedRequest)
-        
+
         let method = recordedRequest?.httpMethod
         XCTAssertNotNil(method)
-        
+
         XCTAssertEqual(method!, "POST")
     }
-    
+
     func test_delete_createDELETERequest() {
         let service = WebService(baseURLString:  "http://httpbin.org/")
         let session = RequestRecordingSession()
         service.session = session
-        
+
         let task = service.DELETE("/delete")
         task.resume()
-        
+
         let recordedRequest = session.recordedRequests.first?.urlRequestValue
         XCTAssertNotNil(recordedRequest)
-        
+
         let method = recordedRequest?.httpMethod
         XCTAssertNotNil(method)
-        
+
         XCTAssertEqual(method!, "DELETE")
     }
-    
+
     func test_head_createHEADRequest() {
         let service = WebService(baseURLString:  "http://httpbin.org/")
         let session = RequestRecordingSession()
         service.session = session
-        
+
         let task = service.HEAD("/head")
         task.resume()
-        
+
         let recordedRequest = session.recordedRequests.first?.urlRequestValue
         XCTAssertNotNil(recordedRequest)
-        
+
         let method = recordedRequest?.httpMethod
         XCTAssertNotNil(method)
-        
+
         XCTAssertEqual(method!, "HEAD")
     }
-    
+
     func test_put_createPUTRequest() {
         let service = WebService(baseURLString:  "http://httpbin.org/")
         let session = RequestRecordingSession()
         service.session = session
-        
+
         let task = service.PUT("/put")
         task.resume()
-        
+
         let recordedRequest = session.recordedRequests.first?.urlRequestValue
         XCTAssertNotNil(recordedRequest)
-        
+
         let method = recordedRequest?.httpMethod
         XCTAssertNotNil(method)
-        
+
         XCTAssertEqual(method!, "PUT")
     }
 }
@@ -102,6 +102,112 @@ class WebServiceTests: XCTestCase {
 // MARK: - absoluteURLString
 
 extension WebServiceTests {
+
+    func test_absoluteURLString_emptyBase() {
+        let service = WebService(baseURLString: "")
+
+        let url = service.absoluteURLString("http://www.walmart.com/v1/foo/bar")
+
+        XCTAssertEqual(url, "http://www.walmart.com/v1/foo/bar")
+    }
+
+    func test_absoluteURLString_emptyRelative() {
+        let service = WebService(baseURLString: "http://www.walmart.com/v1/foo")
+
+        let url = service.absoluteURLString("")
+
+        XCTAssertEqual(url, "http://www.walmart.com/v1/foo")
+    }
+
+    func test_absoluteURLString_relativeHasScheme() {
+        let service = WebService(baseURLString: "http://www.walmart.com")
+
+        // When the relative URL has a scheme, should replace the entire base URL
+        let url = service.absoluteURLString("http://www.amazon.com")
+
+        XCTAssertEqual(url, "http://www.amazon.com")
+    }
+
+    func test_absoluteURLString_baseNoTrailingSlash_relativeNoLeadingSlash() {
+        let service = WebService(baseURLString: "http://www.walmart.com/v1")
+
+        let url = service.absoluteURLString("foo/bar")
+
+        XCTAssertEqual(url, "http://www.walmart.com/foo/bar") // the v1 is not treated as part of the absolute base since it does not have the trailing slash, but as a relative path that gets replaced
+    }
+
+    func test_absoluteURLString_baseNoTrailingSlash_relativeLeadingSlash() {
+        let service = WebService(baseURLString: "http://www.walmart.com/v1")
+
+        let url = service.absoluteURLString("/foo/bar")
+
+        XCTAssertEqual(url, "http://www.walmart.com/foo/bar") // the v1 is not treated as part of the absolute base since it does not have the trailing slash, but as a relative path that gets replaced
+    }
+
+    func test_absoluteURLString_baseTrailingSlash_relativeNoLeadingSlash() {
+        let service = WebService(baseURLString: "http://www.walmart.com/v1/")
+
+        let url = service.absoluteURLString("foo/bar")
+
+        XCTAssertEqual(url, "http://www.walmart.com/v1/foo/bar")
+    }
+
+    func test_absoluteURLString_baseTrailingSlash_relativeLeadingSlash() {
+        let service = WebService(baseURLString: "http://www.walmart.com/v1/")
+
+        let url = service.absoluteURLString("/foo/bar")
+
+        XCTAssertEqual(url, "http://www.walmart.com/foo/bar") // the v1 is not treated as part of the absolute base since it does not have the trailing slash, but as a relative path that gets replaced
+    }
+
+    func test_absoluteURLString_absolutePath() {
+        let service = WebService(baseURLString: "http://www.walmart.com/v1/bar")
+
+        let url = service.absoluteURLString("/v2/bar")
+
+        XCTAssertEqual(url, "http://www.walmart.com/v2/bar")
+    }
+
+    func test_absoluteURLString_relativeParams() {
+        let service = WebService(baseURLString: "http://www.walmart.com/v1")
+
+        let url = service.absoluteURLString("?foo=bar")
+
+        XCTAssertEqual(url, "http://www.walmart.com/v1?foo=bar")
+    }
+
+    func test_absoluteURLString_baseAndRelativeParams() {
+        let service = WebService(baseURLString: "http://www.walmart.com/v1?foo=bar")
+
+        let url = service.absoluteURLString("?bar=foo")
+
+        XCTAssertEqual(url, "http://www.walmart.com/v1?bar=foo")
+    }
+
+    func test_absoluteURLString_baseParams() {
+        let service = WebService(baseURLString: "http://www.walmart.com/v1/?foo=bar")
+
+        let url = service.absoluteURLString("foo/bar")
+
+        XCTAssertEqual(url, "http://www.walmart.com/v1/foo/bar")
+    }
+
+    func test_absoluteURLString_relativePathAndParams() {
+        let service = WebService(baseURLString: "http://www.walmart.com")
+
+        let url = service.absoluteURLString("/v1/foo/bar?foo=bar")
+
+        XCTAssertEqual(url, "http://www.walmart.com/v1/foo/bar?foo=bar")
+    }
+
+    func test_absoluteURLString_constructsValidURLWhenBaseIsEmpty() {
+        let service = WebService(baseURLString: "")
+
+        let url = service.absoluteURLString("http://localhost:8000/rootPath/v1/foo/bar")
+
+        XCTAssertEqual(url, "http://localhost:8000/rootPath/v1/foo/bar")
+    }
+
     func test_request_constructsValidAbsoluteURL() {
         let service = WebService(baseURLString:  "http://httpbin.org/")
         let session = RequestRecordingSession()
@@ -109,7 +215,6 @@ extension WebServiceTests {
 
         let task = service.request(.GET, path: "get")
         task.resume()
-
 
         let recordedRequest = session.recordedRequests.first?.urlRequestValue
         XCTAssertNotNil(recordedRequest)
@@ -121,45 +226,13 @@ extension WebServiceTests {
         XCTAssertEqual(absoluteString, "http://httpbin.org/get")
     }
 
-    func test_absoluteURLString_constructsValidAbsoluteURL() {
-        let service = WebService(baseURLString: "http://www.walmart.com")
-
-        let url = service.absoluteURLString("/v1/foo/bar")
-
-        XCTAssertEqual(url, "http://www.walmart.com/v1/foo/bar")
-    }
-
-    func test_absoluteURLString_constructsValidURLWhenPathDoesNotStartWithSlash() {
-        let service = WebService(baseURLString: "http://www.walmart.com/")
-
-        let url = service.absoluteURLString("v1/foo/bar")
-
-        XCTAssertEqual(url, "http://www.walmart.com/v1/foo/bar")
-    }
-    
-     func test_absoluteURLString_constructsValidURLWhenBaseHasRootPath() {
-        let service = WebService(baseURLString: "http://localhost:8000/rootPath")
-
-        let url = service.absoluteURLString("/v1/foo/bar")
-
-        XCTAssertEqual(url, "http://localhost:8000/rootPath/v1/foo/bar")
-    }
-
-    func test_absoluteURLString_constructsValidURLWhenBaseHasRootPathWithSlash() {
-        let service = WebService(baseURLString: "http://localhost:8000/rootPath/")
-
-        let url = service.absoluteURLString("v1/foo/bar")
-
-        XCTAssertEqual(url, "http://localhost:8000/rootPath/v1/foo/bar")
-    }
-
 }
 
 // MARK: - servicePassthroughDelegate
 
 extension WebService: ServicePassthroughDataSource {
     static let mockPassthroughDelegate = ServicePassthroughDelegateSpy()
-    
+
     public var servicePassthroughDelegate: ServicePassthroughDelegate {
         return WebService.mockPassthroughDelegate
     }
@@ -168,7 +241,7 @@ extension WebService: ServicePassthroughDataSource {
 extension WebServiceTests {
     func test_servicePassthroughDelegate_setsToSelfWhenImplemented() {
         let service = WebService(baseURLString: "http://httpbin.org/")
-        
+
         XCTAssertNotNil(service.passthroughDelegate)
         XCTAssertTrue(service.passthroughDelegate! === WebService.mockPassthroughDelegate as ServicePassthroughDelegate)
     }
@@ -183,7 +256,7 @@ extension WebServiceTests {
         }
 
         let service = WebService(baseURL: baseURL)
-        XCTAssertEqual(service.baseURL.absoluteString, "http://httpbin.org")
+        XCTAssertEqual(service.baseURL!.absoluteString, "http://httpbin.org")
     }
 
     func test_init_baseURL_passthroughDelegate() {
@@ -192,6 +265,6 @@ extension WebServiceTests {
             return
         }
         let service = WebService(baseURL: baseURL, passthroughDelegate: WebService.mockPassthroughDelegate)
-        XCTAssertEqual(service.baseURL.absoluteString, "http://httpbin.org")
+        XCTAssertEqual(service.baseURL!.absoluteString, "http://httpbin.org")
     }
 }

--- a/Source/Core/Request.swift
+++ b/Source/Core/Request.swift
@@ -106,9 +106,13 @@ public struct Request {
     /// The HTTP method of the request.
     public let method: Method
     
+    public let requestURL: URL
+
     /// The URL string of the HTTP request.
-    public let url: String
-    
+    public var url: String {
+        return requestURL.absoluteString
+    }
+
     /// The body of the HTTP request.
     public var body: Data?
     
@@ -167,13 +171,24 @@ public struct Request {
     
     /**
      Intialize a request value.
+
+     - parameter method: The HTTP request method.
+     - parameter url: The URL string of the HTTP request.
+     */
+    init(_ method: Method, url: URL) {
+        self.method = method
+        self.requestURL = url
+    }
+
+    /**
+     Intialize a request value.
      
      - parameter method: The HTTP request method.
      - parameter url: The URL string of the HTTP request.
     */
-    init(_ method: Method, url: String) {
-        self.method = method
-        self.url = url
+    init(_ method: Method, url urlString: String) {
+        let aURL = URL(string: urlString)!
+        self.init(method, url: aURL)
     }
 }
 

--- a/Source/Core/WebService.swift
+++ b/Source/Core/WebService.swift
@@ -17,16 +17,11 @@ import Foundation
         Base URL of the web service.
         If the base URL is nil, the path is interpreted as an absolute URL.
      */
-    private (set) public var baseURL: URL? = nil
+    public let baseURL: URL?
 
     /// Base URL of the web service (as String).
     public var baseURLString: String {
-        get {
-            return baseURL?.absoluteString ?? ""
-        }
-        set {
-            baseURL = URL(string: baseURLString)
-        }
+        return baseURL?.absoluteString ?? ""
     }
 
     public var session: Session = URLSession.shared
@@ -36,23 +31,14 @@ import Foundation
 
     /**
      Initialize a web service value.
+     - parameter baseURL: URL to use as the base URL of the web service.
      */
-    public override init() {
+    public init(baseURL: URL? = nil) {
+        self.baseURL = baseURL
         super.init()
-
         if let passthroughDataSource = self as? ServicePassthroughDataSource {
             passthroughDelegate = passthroughDataSource.servicePassthroughDelegate
         }
-    }
-
-    /**
-     Initialize a web service value.
-     - parameter baseURL: URL to use as the base URL of the web service.
-     */
-    convenience public init(baseURL: URL?) {
-        self.init()
-
-        self.baseURL = baseURL
     }
 
     /**

--- a/Source/Core/WebService.swift
+++ b/Source/Core/WebService.swift
@@ -165,7 +165,7 @@ extension WebService {
      a given request.
      */
     func request(_ method: Request.Method, path: String) -> ServiceTask {
-        return serviceTask(request: Request(method, url: absoluteURLString(path)))
+        return serviceTask(request: Request(method, url: absoluteURL(path)))
     }
 
     /// Create a service task to fulfill a given request.
@@ -215,26 +215,36 @@ extension WebService: Session {
 extension WebService {
     /**
      Return an absolute URL string relative to the baseURLString value.
-    
+
      - parameter string: URL string.
      - returns: An absolute URL string relative to the value of `baseURLString`.
-    */
-    dynamic public func absoluteURLString(_ string: String) -> String {
-        return constructURLString(string, relativeToURL: baseURL)
+     */
+    dynamic public func absoluteURL(_ string: String) -> URL {
+        return constructURL(string, relativeToURL: baseURL)!
     }
 
     /**
      Return an absolute URL string relative to the baseURLString value.
     
+     - parameter string: URL string.
+     - returns: An absolute URL string relative to the value of `baseURLString`.
+    */
+    dynamic public func absoluteURLString(_ string: String) -> String {
+        return absoluteURL(string).absoluteString
+    }
+
+    /**
+     Return an absolute URL string relative to the baseURLString value.
+
      - parameter string: URL string value.
      - parameter relativeURLString: Value of relative URL string.
      - returns: An absolute URL string.
-    */
-    func constructURLString(_ string: String, relativeToURL: URL?) -> String {
+     */
+    func constructURL(_ string: String, relativeToURL: URL?) -> URL? {
         guard string != "" else { // if string is empty then just return the baseURL
-            return baseURL?.absoluteString ?? ""
+            return baseURL
         }
-        let url = URL(string: string, relativeTo: relativeToURL)!.absoluteString
+        let url = URL(string: string, relativeTo: relativeToURL)
         return url
     }
 }

--- a/Source/Core/WebService.swift
+++ b/Source/Core/WebService.swift
@@ -19,6 +19,16 @@ import Foundation
      */
     private (set) public var baseURL: URL? = nil
 
+    /// Base URL of the web service (as String).
+    public var baseURLString: String {
+        get {
+            return baseURL?.absoluteString ?? ""
+        }
+        set {
+            baseURL = URL(string: baseURLString)
+        }
+    }
+
     public var session: Session = URLSession.shared
     internal fileprivate(set) weak var passthroughDelegate: ServicePassthroughDelegate?
 

--- a/Source/Core/WebService.swift
+++ b/Source/Core/WebService.swift
@@ -14,7 +14,7 @@ import Foundation
 */
 @objc public final class WebService: NSObject {
     /// Base URL of the web service.
-    public let baseURLString: String
+    public let baseURL: URL
     
     public var session: Session = URLSession.shared
     internal fileprivate(set) weak var passthroughDelegate: ServicePassthroughDelegate?
@@ -23,18 +23,48 @@ import Foundation
     
     /**
      Initialize a web service value.
-     - parameter baseURLString: URL string to use as the base URL of the web service.
-    */
-    public init(baseURLString: String) {
-        self.baseURLString = baseURLString
-        
+     - parameter baseURL: URL to use as the base URL of the web service.
+     */
+    public init(baseURL: URL) {
+        self.baseURL = baseURL
+
         super.init()
-        
+
         if let passthroughDataSource = self as? ServicePassthroughDataSource {
             passthroughDelegate = passthroughDataSource.servicePassthroughDelegate
         }
     }
+
+    /**
+     Initialize a web service value.
+     - parameter baseURL: URL to use as the base URL of the web service.
+     - parameter passthroughDelegate: ServicePassthroughDelegate to use for hooking into service request/response events.
+     */
+    public convenience init(baseURL: URL, passthroughDelegate: ServicePassthroughDelegate) {
+        self.init(baseURL: baseURL)
+        self.passthroughDelegate = passthroughDelegate
+    }
+
+    /**
+     Initialize a web service value.
+     - parameter baseURLString: URL string to use as the base URL of the web service.
+     - note:
+     This initializer can cause a runtime crash if the `baseURLString` cannot convert to a URL.
+     It is better to use `init(baseURL: URL)` in place of this.
+    */
+    convenience public init(baseURLString: String) {
+        let baseURL = URL(string: baseURLString)
+        self.init(baseURL: baseURL!)
+    }
     
+    /**
+     Initialize a web service value.
+     - parameter baseURL: URL to use as the base URL of the web service.
+     - parameter passthroughDelegate: ServicePassthroughDelegate to use for hooking into service request/response events.
+     - note:
+     This initializer can cause a runtime crash if the `baseURLString` cannot convert to a URL.
+     It is better to use `init(baseURL: URL, passthroughDelegate: ServicePassthroughDelegate)` in place of this.
+     */
     public convenience init(baseURLString: String, passthroughDelegate: ServicePassthroughDelegate) {
         self.init(baseURLString: baseURLString)
         self.passthroughDelegate = passthroughDelegate
@@ -181,10 +211,10 @@ extension WebService {
      Return an absolute URL string relative to the baseURLString value.
     
      - parameter string: URL string.
-     - returns: An absoulte URL string relative to the value of `baseURLString`.
+     - returns: An absolute URL string relative to the value of `baseURLString`.
     */
     public func absoluteURLString(_ string: String) -> String {
-        return constructURLString(string, relativeToURLString: baseURLString)
+        return constructURLString(string, relativeToURL: baseURL)
     }
     
     /**
@@ -194,8 +224,8 @@ extension WebService {
      - parameter relativeURLString: Value of relative URL string.
      - returns: An absolute URL string.
     */
-    func constructURLString(_ string: String, relativeToURLString relativeURLString: String) -> String {
-        let relativeURL = URL(string: relativeURLString)
-        return URL(string: string, relativeTo: relativeURL)!.absoluteString
+    func constructURLString(_ string: String, relativeToURL: URL) -> String {
+        let urlString =  relativeToURL.appendingPathComponent(string).absoluteString
+        return urlString
     }
 }

--- a/Source/Core/WebService.swift
+++ b/Source/Core/WebService.swift
@@ -17,7 +17,7 @@ import Foundation
         Base URL of the web service.
         If the base URL is nil, the path is interpreted as an absolute URL.
      */
-    public let baseURL: URL?
+    private (set) public var baseURL: URL? = nil
 
     public var session: Session = URLSession.shared
     internal fileprivate(set) weak var passthroughDelegate: ServicePassthroughDelegate?
@@ -26,16 +26,23 @@ import Foundation
 
     /**
      Initialize a web service value.
-     - parameter baseURL: URL to use as the base URL of the web service.
      */
-    public init(baseURL: URL?) {
-        self.baseURL = baseURL
-
+    public override init() {
         super.init()
 
         if let passthroughDataSource = self as? ServicePassthroughDataSource {
             passthroughDelegate = passthroughDataSource.servicePassthroughDelegate
         }
+    }
+
+    /**
+     Initialize a web service value.
+     - parameter baseURL: URL to use as the base URL of the web service.
+     */
+    convenience public init(baseURL: URL?) {
+        self.init()
+
+        self.baseURL = baseURL
     }
 
     /**
@@ -216,7 +223,7 @@ extension WebService {
      - parameter string: URL string.
      - returns: An absolute URL string relative to the value of `baseURLString`.
     */
-    public func absoluteURLString(_ string: String) -> String {
+    dynamic public func absoluteURLString(_ string: String) -> String {
         return constructURLString(string, relativeToURL: baseURL)
     }
 


### PR DESCRIPTION
- Removed `baseURLString`, replaced with `baseURL`
- Added unit tests that cover more cases of the base URL and the relative URL. More clearly documenting the behavior with respect to leading and trailing forwards slashes.
- Made the `absoluteURLString(_:)` method dynamic, to allow for method replacement at runtime to facilitate testing where the URLs are redirected at runtime to a mocking server.
- Converted `Request` to use a URL internally rather than String.