### PR TITLE
enable `ServiceTask` to collect performance metrics during execution

### DIFF
--- a/ELWebService.xcodeproj/project.pbxproj
+++ b/ELWebService.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		17821A031C623D2C00D3837D /* ServiceTask+ResponseInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17821A021C623D2C00D3837D /* ServiceTask+ResponseInjection.swift */; };
 		17BA678F1C8416C500A26309 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BA678E1C8416C500A26309 /* Session.swift */; };
 		17C96AAB1AB0CBB800D49071 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = 17C96AAA1AB0CBB800D49071 /* LICENSE */; };
+		17D064691F3425A6007E1035 /* ServiceTaskMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D064681F3425A6007E1035 /* ServiceTaskMetrics.swift */; };
 		17D1879E1AB0B173000742BF /* ELWebService.h in Headers */ = {isa = PBXBuildFile; fileRef = 17D187991AB0B173000742BF /* ELWebService.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CAF0AF991C5054DE0007761C /* WebService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17088EDF1C5011FB007ADE1B /* WebService.swift */; };
 		CAF0AF9B1C5054E60007761C /* ServiceTaskResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17088EE11C5011FB007ADE1B /* ServiceTaskResult.swift */; };
@@ -62,6 +63,7 @@
 		179C5C5E1AB079980047169F /* ELWebService.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ELWebService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		17BA678E1C8416C500A26309 /* Session.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Session.swift; sourceTree = "<group>"; };
 		17C96AAA1AB0CBB800D49071 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
+		17D064681F3425A6007E1035 /* ServiceTaskMetrics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServiceTaskMetrics.swift; sourceTree = "<group>"; };
 		17D187961AB0B173000742BF /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		17D187991AB0B173000742BF /* ELWebService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ELWebService.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -152,6 +154,7 @@
 				17547AD51C6121E200D4B030 /* ServiceTask+ObjC.swift */,
 				17BA678E1C8416C500A26309 /* Session.swift */,
 				17088EDF1C5011FB007ADE1B /* WebService.swift */,
+				17D064681F3425A6007E1035 /* ServiceTaskMetrics.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -290,6 +293,7 @@
 				17BA678F1C8416C500A26309 /* Session.swift in Sources */,
 				17547AD61C6121E200D4B030 /* ServiceTask+ObjC.swift in Sources */,
 				1720E8241C6A483100DBB925 /* ServicePassthroughDelegate.swift in Sources */,
+				17D064691F3425A6007E1035 /* ServiceTaskMetrics.swift in Sources */,
 				CAF0AF9B1C5054E60007761C /* ServiceTaskResult.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ELWebServiceTests/ServicePassthroughDelegateTests.swift
+++ b/ELWebServiceTests/ServicePassthroughDelegateTests.swift
@@ -101,6 +101,7 @@ class ServicePassthroughDelegateSpy: ServicePassthroughDelegate {
     var updateUIBeginExpectation: XCTestExpectation?
     var updateUIEndExpectation: XCTestExpectation?
     var serviceResultFailureExpecation: XCTestExpectation?
+    var metricsCollectedExpectation: XCTestExpectation?
     
     func requestSent(_ request: URLRequest) {
         requestSentExpectation?.fulfill()
@@ -120,5 +121,9 @@ class ServicePassthroughDelegateSpy: ServicePassthroughDelegate {
     
     func serviceResultFailure(_ response: URLResponse?, data: Data?, request: URLRequest?, error: Error) {
         serviceResultFailureExpecation?.fulfill()
+    }
+    
+    func didFinishCollectingTaskMetrics(metrics: ServiceTaskMetrics, request: URLRequest, response: URLResponse?, error: Error?) {
+        metricsCollectedExpectation?.fulfill()
     }
 }

--- a/Source/Core/ServicePassthroughDelegate.swift
+++ b/Source/Core/ServicePassthroughDelegate.swift
@@ -26,6 +26,9 @@ public protocol ServicePassthroughDelegate: class {
     func serviceResultFailure(_ response: URLResponse?, data: Data?, request: URLRequest?, error: Error)
     
     func modifiedRequest(_ request: URLRequest) -> URLRequest?
+    
+    /// Called when service task metrics are available upon response completion
+    func didFinishCollectingTaskMetrics(metrics: ServiceTaskMetrics, request: URLRequest, response: URLResponse?, error: Error?)
 }
 
 extension ServicePassthroughDelegate {

--- a/Source/Core/ServiceTask.swift
+++ b/Source/Core/ServiceTask.swift
@@ -32,6 +32,8 @@ import Foundation
         return .suspended
     }
     
+    fileprivate(set) var metrics = ServiceTaskMetrics()
+    
     fileprivate var request: Request
     
     lazy fileprivate var urlRequest: URLRequest = {
@@ -186,6 +188,7 @@ extension ServiceTask {
             }
         }
         
+        metrics.fetchStartDate = Date()
         dataTask?.resume()
         return self
     }
@@ -202,6 +205,8 @@ extension ServiceTask {
     
     /// Handle the response and kick off the handler queue
     internal func handleResponse(_ response: URLResponse?, data: Data?, error: Error?) {
+        metrics.responseEndDate = Date()
+        passthroughDelegate?.didFinishCollectingTaskMetrics(metrics: metrics, request: urlRequest, response: response, error: error)
         urlResponse = response
         responseData = data
         responseError = error

--- a/Source/Core/ServiceTask.swift
+++ b/Source/Core/ServiceTask.swift
@@ -34,9 +34,9 @@ import Foundation
     
     fileprivate var request: Request
     
-    fileprivate var urlRequest: URLRequest {
-        return request.urlRequestValue as URLRequest
-    }
+    lazy fileprivate var urlRequest: URLRequest = {
+        return self.request.urlRequestValue as URLRequest
+    }()
     
     /// Dispatch queue that queues up and dispatches handler blocks
     fileprivate let handlerQueue: OperationQueue

--- a/Source/Core/ServiceTaskMetrics.swift
+++ b/Source/Core/ServiceTaskMetrics.swift
@@ -1,0 +1,18 @@
+//
+//  ServiceTaskMetrics.swift
+//  ELWebService
+//
+//  Created by Angelo Di Paolo on 8/4/17.
+//  Copyright © 2017 WalmartLabs. All rights reserved.
+//
+
+import Foundation
+
+/// Encapsulates performance metrics collected during the execution of a service task.
+public struct ServiceTaskMetrics {
+    /// The time immediately after the` URLSessionDataTask`'s `resume` method is called.
+    public internal(set) var fetchStartDate: Date?
+    
+    /// The time immediately after the `URLSessionDataTask`'s completion handler is called.
+    public internal(set) var responseEndDate: Date?
+}


### PR DESCRIPTION
Added a new metrics API, `ServiceTaskMetrics`, that provides `fetchStartDate` and `responseEndDate` time stamps. This enables us to measure the time interval between request sent and response recieved.

The design is loosely-based on iOS 10's [metrics API](https://developer.apple.com/documentation/foundation/urlsessiontasktransactionmetrics) for `URLSession`. Ideally we should move to iOS's metrics API after we drop iOS 9 support and can fully utilize it for all user sessions. I considered conditionally using iOS's metrics API for users that are running iOS 10 and up but I was concerned about collecting inconsistent metrics between our metrics implementation and the system's.