### PR TITLE
Make the WebService->request method public so external interfaces can…

### DIFF
--- a/Source/Core/WebService.swift
+++ b/Source/Core/WebService.swift
@@ -164,7 +164,7 @@ extension WebService {
      - returns: A ServiceTask instance that refers to the lifetime of processing
      a given request.
      */
-    func request(_ method: Request.Method, path: String) -> ServiceTask {
+    public func request(_ method: Request.Method, path: String) -> ServiceTask {
         return serviceTask(request: Request(method, url: absoluteURL(path)))
     }
 


### PR DESCRIPTION
… more dynamically create ServiceTasks. This makes the interface using ObjectMapper and the NetworkRouter enum much cleaner.