### PR TITLE
Make the default URLSession modifiable within the app 

### DIFF
--- a/Source/Core/WebService.swift
+++ b/Source/Core/WebService.swift
@@ -24,7 +24,23 @@ import Foundation
         return baseURL?.absoluteString ?? ""
     }
 
-    public var session: Session = URLSession.shared
+    /**
+     Default session that will be used by instances of WebService for their
+     subsequent communications. This is broken out separately from the per-instance
+     session so that application global configuration can be done, such as setting
+     additionalHTTPHeaders, that will then apply throughout the application.
+     */
+    public static var defaultSession: Session = URLSession.shared
+    
+    /**
+     The session is a lazy variable so that in the time between the creation of
+     a WebService instance and the first request made to that service the
+     defaultSession could be replaced and the instance would still use that
+     default value rather than requiring the defaultSession to be configured
+     before the WebService instance is even created.
+     */
+    public lazy var session: Session = WebService.defaultSession
+    
     public weak var passthroughDelegate: ServicePassthroughDelegate?
 
     // MARK: Initialization


### PR DESCRIPTION
This allows an application to do additional configuration to the URLSession used by all WebService instances that have not yet sent a request.

It is common in a typical application for consumers of WebServices to create the WebService instances before doing application wide configuration, which may lead to configuring the URLSession that all WebServices should use. Thus the session instance variable is made lazy so that individual instances don't enshrine it's value from the defaultSession until they need to actually make a request.

One common configuration task is to create a new URLSession using a URLSessionConfiguration object which specifies a value for httpAdditionalHeaders that are to be sent with every request.