### PR TITLE
Provision to disable cookies for a request

### DIFF
--- a/Source/Core/Request.swift
+++ b/Source/Core/Request.swift
@@ -118,6 +118,9 @@ public struct Request {
     /// The body of the HTTP request.
     public var body: Data?
     
+    /// The Boolean to indicate if default cookies should be set for request.
+    public var shouldHandleCookies: Bool = true
+
     /**
      The parameters to encode in the HTTP request. Request parameters are percent
      encoded and are appended as a query string or set as the request body 
@@ -210,6 +213,7 @@ extension Request: URLRequestEncodable {
         let urlRequest = NSMutableURLRequest(url: URL(string: url)!)
         urlRequest.httpMethod = method.rawValue
         urlRequest.cachePolicy = cachePolicy
+        urlRequest.httpShouldHandleCookies = shouldHandleCookies
         
         for (name, value) in headers {
             urlRequest.addValue(value, forHTTPHeaderField: name)

--- a/Source/Core/ServiceTask.swift
+++ b/Source/Core/ServiceTask.swift
@@ -107,6 +107,12 @@ import Foundation
 
 extension ServiceTask {
     /// TODO: Needs docs
+    @discardableResult public func shouldHandleCookies(_ handle: Bool) -> Self {
+        urlRequest.httpShouldHandleCookies = handle
+        return self
+    }
+    
+    /// TODO: Needs docs
     @discardableResult public func setParameters(_ parameters: [String: Any], encoding: Request.ParameterEncoding? = nil) -> Self {
         request.parameters = parameters
         request.parameterEncoding = encoding ?? .percent

--- a/Source/Core/ServiceTask.swift
+++ b/Source/Core/ServiceTask.swift
@@ -106,9 +106,17 @@ import Foundation
 // MARK: - Request API
 
 extension ServiceTask {
-    /// TODO: Needs docs
-    @discardableResult public func shouldHandleCookies(_ handle: Bool) -> Self {
-        urlRequest.httpShouldHandleCookies = handle
+    
+    /**
+     Sets a boolean that indicates whether the receiver should use the default
+     cookie handling for the request.
+     
+     - parameter handle: true if the receiver should use the default cookie
+     handling for the request, false otherwise. The default is true.
+     - returns: Self instance to support chaining.
+     */
+    @discardableResult public func setShouldHandleCookies(_ handle: Bool) -> Self {
+        request.shouldHandleCookies = handle
         return self
     }
     


### PR DESCRIPTION
@angelodipaolo 
We don't have access to the urlRequest to set "httpShouldHandleCookie" property for the request.
Hence creating a public method