### PR TITLE
add callback to read response time at the `ServiceTask` level

### DIFF
--- a/Source/Core/ServiceTask.swift
+++ b/Source/Core/ServiceTask.swift
@@ -74,6 +74,8 @@ import Foundation
     
     fileprivate var json: Any?
     
+    fileprivate var metricsHandler: MetricsHandler?
+    
     /// Delegate interface for handling raw response and request events
     internal weak var passthroughDelegate: ServicePassthroughDelegate?
     
@@ -221,6 +223,7 @@ extension ServiceTask {
     internal func handleResponse(_ response: URLResponse?, data: Data?, error: Error?) {
         metrics.responseEndDate = Date()
         passthroughDelegate?.didFinishCollectingTaskMetrics(metrics: metrics, request: urlRequest, response: response, data: data, error: error)
+        metricsHandler?(metrics, response)
         urlResponse = response
         responseData = data
         responseError = error
@@ -353,6 +356,24 @@ extension ServiceTask {
                 return try handler(json, response)
             }
         }
+    }
+}
+
+// MARK: - Metrics
+
+extension ServiceTask {
+    public typealias MetricsHandler = (ServiceTaskMetrics, URLResponse?) -> Void
+    
+    /**
+     Set a callback that will be invoked when service task metrics have been
+     collected
+     
+     - parameter handler: Callback to invoke when metrics have been collected.
+     - returns: Self instance to support chaining.
+     */
+    public func metricsCollected(_ handler: @escaping MetricsHandler) -> Self {
+        metricsHandler = handler
+        return self
     }
 }
 

--- a/docs/Programming-Guide.md
+++ b/docs/Programming-Guide.md
@@ -14,6 +14,7 @@
 - [Objective-C Interoperability](#objective-c-interoperability)
 - [Mocking](#mocking)
 - [Logging](#logging)
+- [Metrics](#metrics)
 
 ## About ELWebService
 
@@ -831,6 +832,36 @@ class RequestLogger: ServicePassthroughDelegate {
 
     // other protocol methods…
 }
+```
+
+## Metrics
+
+ELWebService automatically measures response time as a time interval between when `resume()` is first called and when the completion handler of the underlying `URLSessionTask` is called.
+
+### Capture All Response Times
+
+Capture response times for all responses using the `ServicePassthroughDelegate`'s `didFinishCollectingTaskMetrics(metrics:request:response:data:error:)` method.
+
+```
+extension StandardAnalytics: ServicePassthroughDelegate {
+    public func didFinishCollectingTaskMetrics(metrics: ServiceTaskMetrics, request: URLRequest, response: URLResponse?, data: Data?, error: Error?) {
+        let responseTime: TimeInterval? = metrics.responseTime
+        // log metrics
+    }
+```
+
+### Capture Individual Response
+
+Set the `metricsCollected` handler to capture metrics for a particular `ServiceTask` instance.
+
+```
+let task = service
+    .GET("/brewers")
+    .metricsCollected { metrics, response in
+        let responseTime: TimeInterval? = metrics.responseTime
+
+    }
+    .resume()
 ```
 
 ## More Information


### PR DESCRIPTION
Adds an API for reading the response time of an individual service task. Previously, response times could only be read by reading all response times of the service via `ServiceTaskDelegate`.