### PR TITLE
collect responseJSON and updateUI execution time

### DIFF
--- a/Source/Core/ServiceTask.swift
+++ b/Source/Core/ServiceTask.swift
@@ -77,7 +77,7 @@ import Foundation
     
     fileprivate var metricsHandler: MetricsHandler?
     
-    fileprivate var wasSuspended = false
+    fileprivate var hasEverBeenSuspended = false
     
     /// Delegate interface for handling raw response and request events
     internal weak var passthroughDelegate: ServicePassthroughDelegate?
@@ -211,7 +211,7 @@ extension ServiceTask {
         dataTask?.resume()
         
         // run metrics handler at end of queue
-        if !wasSuspended {
+        if !hasEverBeenSuspended {
             handlerQueue.addOperation {
                 self.sendMetrics()
             }
@@ -222,7 +222,7 @@ extension ServiceTask {
     
     /// Suspend the underlying data task.
     public func suspend() {
-        wasSuspended = true
+        hasEverBeenSuspended = true
         dataTask?.suspend()
     }
     

--- a/Source/Core/ServiceTask.swift
+++ b/Source/Core/ServiceTask.swift
@@ -233,7 +233,6 @@ extension ServiceTask {
     /// Handle the response and kick off the handler queue
     internal func handleResponse(_ response: URLResponse?, data: Data?, error: Error?) {
         metrics.responseEndDate = Date()
-        passthroughDelegate?.didFinishCollectingTaskMetrics(metrics: metrics, request: urlRequest, response: response, data: data, error: error)
         urlResponse = response
         responseData = data
         responseError = error

--- a/Source/Core/ServiceTask.swift
+++ b/Source/Core/ServiceTask.swift
@@ -351,9 +351,12 @@ extension ServiceTask {
             if let json = self.json {
                 return try handler(json, response)
             } else {
+                self.metrics.responseJSONStartDate = Date()
                 let json = try JSONSerialization.jsonObject(with: data, options: JSONSerialization.ReadingOptions.allowFragments)
                 self.json = json
-                return try handler(json, response)
+                let result = try handler(json, response)
+                self.metrics.responseJSONEndDate = Date()
+                return result
             }
         }
     }

--- a/Source/Core/ServiceTask.swift
+++ b/Source/Core/ServiceTask.swift
@@ -32,7 +32,8 @@ import Foundation
         return .suspended
     }
     
-    fileprivate(set) var metrics = ServiceTaskMetrics()
+    /// Performance metrics collected during the execution of a service task
+    public fileprivate(set) var metrics = ServiceTaskMetrics()
     
     fileprivate var request: Request
     

--- a/Source/Core/ServiceTask.swift
+++ b/Source/Core/ServiceTask.swift
@@ -327,7 +327,9 @@ extension ServiceTask {
                 
                 DispatchQueue.main.sync {
                     self.passthroughDelegate?.updateUIBegin(self.urlResponse)
+                    self.metrics.updateUIStartDate = Date()
                     handler(value)
+                    self.metrics.updateUIEndDate = Date()
                     self.passthroughDelegate?.updateUIEnd(self.urlResponse)
                 }
             } catch _ {

--- a/Source/Core/ServiceTaskMetrics.swift
+++ b/Source/Core/ServiceTaskMetrics.swift
@@ -18,9 +18,24 @@ public struct ServiceTaskMetrics {
     
     /// The time interval between `fetchStartDate` and `responseEndDate`
     public var responseTime: TimeInterval? {
+        return timeInterval(startDate: fetchStartDate, endDate: responseEndDate)
+    }
+    
+    /// The time immediately before the response data is deserialized by JSONSerialization.
+    public internal(set) var responseJSONStartDate: Date?
+
+    /// The time immediately after the `responseJSON` handler returns.
+    public internal(set) var responseJSONEndDate: Date?
+    
+    /// The time interval between `fetchStartDate` and `responseEndDate`
+    public var deserializationTime: TimeInterval? {
+        return timeInterval(startDate: responseJSONStartDate, endDate: responseJSONEndDate)
+    }
+    
+    private func timeInterval(startDate: Date?, endDate: Date?) -> TimeInterval? {
         guard
-            let startDate = fetchStartDate,
-            let endDate = responseEndDate else {
+            let startDate = startDate,
+            let endDate = endDate else {
                 return nil
         }
         return endDate.timeIntervalSince(startDate)

--- a/Source/Core/ServiceTaskMetrics.swift
+++ b/Source/Core/ServiceTaskMetrics.swift
@@ -32,6 +32,17 @@ public struct ServiceTaskMetrics {
         return timeInterval(startDate: responseJSONStartDate, endDate: responseJSONEndDate)
     }
     
+    /// The time immediately before the updateUI handler is called.
+    public internal(set) var updateUIStartDate: Date?
+    
+    /// The time immediately after the `updateUI` handler returns.
+    public internal(set) var updateUIEndDate: Date?
+    
+    /// The time interval between `updateUIStartDate` and `updateUIEndDate`
+    public var updateUITime: TimeInterval? {
+        return timeInterval(startDate: updateUIStartDate, endDate: updateUIEndDate)
+    }
+    
     private func timeInterval(startDate: Date?, endDate: Date?) -> TimeInterval? {
         guard
             let startDate = startDate,

--- a/Source/Core/ServiceTaskMetrics.swift
+++ b/Source/Core/ServiceTaskMetrics.swift
@@ -27,8 +27,8 @@ public struct ServiceTaskMetrics {
     /// The time immediately after the `responseJSON` handler returns.
     public internal(set) var responseJSONEndDate: Date?
     
-    /// The time interval between `fetchStartDate` and `responseEndDate`
-    public var deserializationTime: TimeInterval? {
+    /// The time interval between `responseJSONStartDate` and `responseJSONEndDate`
+    public var responseJSONTime: TimeInterval? {
         return timeInterval(startDate: responseJSONStartDate, endDate: responseJSONEndDate)
     }
     

--- a/docs/Programming-Guide.md
+++ b/docs/Programming-Guide.md
@@ -857,8 +857,17 @@ Set the `metricsCollected` handler to capture metrics for a particular `ServiceT
 ```
 let task = service
     .GET("/brewers")
+    .responseJSON { json, response in
+        if let models: [Brewer] = JSONDecoder<Brewer>.decode(json)  {
+            return .Value(models)
+        } else {
+            // any value conforming to ErrorType
+            return .Failure(JSONDecoderError.FailedToDecodeBrewer)
+        }
+    }
     .metricsCollected { metrics, response in
         let responseTime: TimeInterval? = metrics.responseTime
+        let jsonTime: TimeInterval? = metrics.responseJSONTime
 
     }
     .resume()


### PR DESCRIPTION
- Collect `responseJSON` and `updateUI` handler execution times as part of service task metrics.
- Send metrics at the end of handler queue execution so `responseJSON` and `updateUI` times can be measured first.