### PR TITLE
Add ability to set custom content-type header on `ServiceTask`

### DIFF
--- a/ELWebServiceTests/ServiceTaskTests.swift
+++ b/ELWebServiceTests/ServiceTaskTests.swift
@@ -693,7 +693,26 @@ extension ServiceTaskTests {
         XCTAssertEqual(recordedURLRequest!.httpBody, bodyData)
         
     }
-    
+
+    // setBodyContentType
+
+    func test_setBodyContentType_setsHTTPBodyAndContentTypeHaderInURLRequest() {
+        let bodyData = Data()
+        let contentType = "image/png"
+        let request = Request(.GET, url: "/test_setBodyContentType_setsHTTPBodyAndContentTypeHaderInURLRequest")
+        let session = RequestRecordingSession()
+        let task = ServiceTask(request: request, session: session)
+
+        task.setBody(bodyData, contentType: contentType)
+        task.resume()
+
+        let recordedURLRequest = session.recordedRequests.first?.urlRequestValue
+        XCTAssertNotNil(recordedURLRequest)
+        XCTAssertEqual(recordedURLRequest!.httpBody, bodyData)
+        XCTAssertEqual(recordedURLRequest?.allHTTPHeaderFields?[Request.Headers.contentType], contentType)
+    }
+
+
     func test_setCachePolicy_setsPolicyInURLRequest() {
         let request = Request(.GET, url: "/test_setBody_encodesDataInURLRequest")
         let session = RequestRecordingSession()
@@ -705,10 +724,8 @@ extension ServiceTaskTests {
         let recordedURLRequest = session.recordedRequests.first?.urlRequestValue
         XCTAssertNotNil(recordedURLRequest)
         XCTAssertEqual(recordedURLRequest!.cachePolicy, NSURLRequest.CachePolicy.reloadIgnoringLocalCacheData)
-        
     }
-    
-    
+
     // setJSON
     
     func test_setParametersEncoding_setsParameterEncodingInRequest() {
@@ -723,6 +740,24 @@ extension ServiceTaskTests {
         let recordedURLRequest = session.recordedRequests.first?.urlRequestValue
         XCTAssertNotNil(recordedURLRequest)
         XCTAssertNotNil(recordedURLRequest?.httpBody)
+    }
+
+    // setJSONData
+
+    func test_setBodyAndContentType_setsBodyAndContentTypeHeaderInRequest() {
+        let request = Request(.POST, url: "/test_setBodyAndContentType_setsBodyAndContentTypeHeaderInRequest")
+        let contentType = "image/jpg"
+        let bodyData = Data()
+        let session = RequestRecordingSession()
+        let task = ServiceTask(request: request, session: session)
+
+        task.setBody(bodyData, contentType: contentType)
+        task.resume()
+
+        let recordedURLRequest = session.recordedRequests.first?.urlRequestValue
+        XCTAssertNotNil(recordedURLRequest)
+        XCTAssertEqual(recordedURLRequest!.httpBody, bodyData)
+        XCTAssertEqual(recordedURLRequest?.allHTTPHeaderFields?[Request.Headers.contentType], contentType)
     }
     
     // setParameters

--- a/Source/Core/ServiceTask.swift
+++ b/Source/Core/ServiceTask.swift
@@ -132,18 +132,38 @@ extension ServiceTask {
         
         return self
     }
-    
-    /// TODO: Needs docs
+
     @discardableResult public func setBody(_ data: Data) -> Self {
         request.body = data
         return self
     }
-    
+
+    /// Sets the `body` of the request to the provided `data` and the `Content-Type` header to `contentType`.
+    ///
+    /// - Parameters:
+    ///   - data: A `Data` instance.
+    ///   - contentType: The `Content-Type` header value describing the type of `data`.
+    /// - Returns: `self`
+    @discardableResult public func setBody(_ data: Data, contentType: String) -> Self {
+        request.body = data
+        request.contentType = contentType
+        return self
+    }
+
     /// TODO: Needs docs
     @discardableResult public func setJSON(_ json: Any) -> Self {
         request.contentType = Request.ContentType.json
         request.body = try? JSONSerialization.data(withJSONObject: json, options: JSONSerialization.WritingOptions(rawValue: 0))
         return self
+    }
+
+    /// Sets the `body` of the `Request` to the provided `json` data and the `Content-Type` header
+    /// to `application/json`.
+    ///
+    /// - Parameter json: A `Data` instance containing JSON data.
+    /// - Returns: `self`
+    @discardableResult public func setJSONData(_ json: Data) -> Self {
+        return setBody(json, contentType: Request.ContentType.json)
     }
     
     /// TODO: Needs docs


### PR DESCRIPTION
[Also, add convenience setter for JSON data]

Consumers are forced to jump through hoops to take advantage of the new `Codable` APIs... e.g.

```
webService.POST(Endpoint.user.url(with: baseURL))
.setBody(bodyData)
.setHeaderValue("application/json", forName: "Content-Type")
```

```
let data = try JSONEncoder().encode(payload)
jsonObject = try JSONSerialization.jsonObject(with: data)
...
webService.POST(Endpoint.user.url(with: baseURL))
.setJSON(jsonObject)
```

With this change, the call site would be simplified to: 
```
.setJSONData(json)
```
