### PR TITLE
Adds support for percent-encoding the body while specifying allowed characters

### DIFF
--- a/ELWebServiceTests/ParameterEncodingTests.swift
+++ b/ELWebServiceTests/ParameterEncodingTests.swift
@@ -74,7 +74,19 @@ class ParameterEncodingTests: XCTestCase {
         XCTAssertEqual(components[0], "percentEncoded")
         XCTAssertEqual(components[1], "this%20needs%20percent%20encoded")
     }
-    
+
+    func test_encodeBody_charSet() {
+        let parameters = ["percentEncoded" : "this + needs percent / encoded"]
+        let encoding = Request.ParameterEncoding.percent
+        let encodedData = encoding.encodeBody(parameters, allowedCharacters: CharacterSet.alphanumerics)
+        XCTAssertNotNil(encodedData, "Encoded body should be non-nil")
+
+        let stringValue = NSString(data: encodedData!, encoding: String.Encoding.utf8.rawValue)!
+        let components = stringValue.components(separatedBy: "=")
+        XCTAssertEqual(components[0], "percentEncoded")
+        XCTAssertEqual(components[1], "this%20%2B%20needs%20percent%20%2F%20encoded")
+    }
+
     func test_encodeBody_encodesJSONParameters() {
         let encoding = Request.ParameterEncoding.json
         let parameters: [String: Any] = ["foo" : "bar", "paramName" : "paramValue", "number" : 42]

--- a/Source/Core/Request.swift
+++ b/Source/Core/Request.swift
@@ -135,7 +135,7 @@ public struct Request {
     /// The key/value pairs that are encoded as form data in the request body.
     public var formParameters: [String : Any]? {
         didSet {
-            if let formData = formParameters?.percentEncodedData {
+            if let formData = formParameters?.percentEncodedData(with: formParametersAllowedCharacters) {
                 body = formData
                 contentType = ContentType.formEncoded
             }
@@ -146,6 +146,9 @@ public struct Request {
         return url?.URLByAppendingQueryItems(parameters.queryItems)
     }
 
+    /**
+    If form parameters are specified, characters not in this set will be percent-encoded
+    */
     public var formParametersAllowedCharacters: CharacterSet? = nil
 
     /**
@@ -261,11 +264,7 @@ extension URLRequest: URLRequestEncodable {
 // MARK: - Query String
 
 extension Dictionary {
-    /// Return an encoded query string using the elements in the dictionary.
-    var percentEncodedQueryString: String? {
-        return percentEncodedQueryString(with: nil)
-    }
-    
+
     var queryItems: [URLQueryItem] {
         var items = [URLQueryItem]()
         
@@ -287,10 +286,24 @@ extension Dictionary {
         return items
     }
     
+    // Default encoding
     var percentEncodedData: Data? {
-        return percentEncodedQueryString(with: formParametersAllowedCharacters)?.data(using: String.Encoding.utf8, allowLossyConversion: false)
+        return percentEncodedData(with: nil)
     }
 
+    // Encoding with custom allowed character set
+    func percentEncodedData(with allowedCharacters: CharacterSet?) -> Data? {
+        return percentEncodedQueryString(with: allowedCharacters)?.data(using: String.Encoding.utf8, allowLossyConversion: false)
+    }
+
+    /// Return an encoded query string using the elements in the dictionary.
+
+    // Default encoding
+    var percentEncodedQueryString: String? {
+        return percentEncodedQueryString(with: nil)
+    }
+
+    // Encoding with custom allowed character set
     func percentEncodedQueryString(with allowedCharacters: CharacterSet?) -> String? {
         var components = URLComponents(string: "")
         components?.queryItems = queryItems

--- a/Source/Core/Request.swift
+++ b/Source/Core/Request.swift
@@ -146,6 +146,8 @@ public struct Request {
         return url?.URLByAppendingQueryItems(parameters.queryItems)
     }
 
+    public var formParametersAllowedCharacters: CharacterSet? = nil
+
     /**
      The HTTP header fields of the request. Each key/value pair represents a 
      HTTP header field value using the key as the field name.
@@ -286,7 +288,7 @@ extension Dictionary {
     }
     
     var percentEncodedData: Data? {
-        return percentEncodedQueryString?.data(using: String.Encoding.utf8, allowLossyConversion: false)
+        return percentEncodedQueryString(with: formParametersAllowedCharacters)?.data(using: String.Encoding.utf8, allowLossyConversion: false)
     }
 
     func percentEncodedQueryString(with allowedCharacters: CharacterSet?) -> String? {

--- a/Source/Core/ServiceTask.swift
+++ b/Source/Core/ServiceTask.swift
@@ -214,6 +214,12 @@ extension ServiceTask {
         request.formParameters = parameters
         return self
     }
+
+    /// Sets the key/value pairs that are encoded as form data in the request body.
+    @discardableResult public func setFormParametersAllowedCharacters(_ allowedCharacters: CharacterSet) -> Self {
+        request.formParametersAllowedCharacters = allowedCharacters
+        return self
+    }
 }
 
 // MARK: - NSURLSesssionDataTask


### PR DESCRIPTION
The current implementation of ELWebService doesn't allow form data to be percent-encoded with a custom set of allowed characters. This is necessary, for example, when server-side handling of `+` and `/` characters differs. Although these are legal URL characters, if they are to be passed as data, they must be percent encoded.