### PR TITLE
Add .Custom case to ParameterEncoding to accommodate parameter encodi…

### DIFF
--- a/Source/Core/ServiceTask.swift
+++ b/Source/Core/ServiceTask.swift
@@ -44,6 +44,10 @@ import Foundation
         return self.request.urlRequestValue as URLRequest
     }()
     
+    public var url: URL? {
+        return urlRequest.url
+    }
+    
     /// Dispatch queue that queues up and dispatches handler blocks
     fileprivate let handlerQueue: OperationQueue
     


### PR DESCRIPTION
…ng for services that do not work with standard encoding schemes

Exposed Servicetask url to public