### PR TITLE
avoid analyze and run steps for test target when building dylib scheme

### DIFF
--- a/ELWebService.xcodeproj/xcshareddata/xcschemes/ELWebService.xcscheme
+++ b/ELWebService.xcodeproj/xcshareddata/xcschemes/ELWebService.xcscheme
@@ -22,10 +22,10 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "17088ED01C5010EA007ADE1B"


### PR DESCRIPTION
Fixes `Signing for "ELWebServiceTests" requires a development team. Select a development team in the project editor. (in target 'ELWebServiceTests')` error when building ELWebService dylib scheme with `xcodebuild`