### PR TITLE
Abstracting  `HTTP` type from Request class

### DIFF
--- a/ELWebService.xcodeproj/project.pbxproj
+++ b/ELWebService.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		3E8CA4AB20E587CB00CBDA69 /* ServiceTaskResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17088EE11C5011FB007ADE1B /* ServiceTaskResult.swift */; };
 		3E8CA4AE20E587CB00CBDA69 /* ELWebService.h in Headers */ = {isa = PBXBuildFile; fileRef = 17D187991AB0B173000742BF /* ELWebService.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3E8CA4B020E587CB00CBDA69 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = 17C96AAA1AB0CBB800D49071 /* LICENSE */; };
+		5A738AB9234E564E00643BF7 /* StringValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A738AB8234E564E00643BF7 /* StringValue.swift */; };
+		5A738ABD234E5BE700643BF7 /* HTTP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A738ABC234E5BE700643BF7 /* HTTP.swift */; };
 		B6A79DEF2204E24500059604 /* AsyncData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D3D2CE2203C70400B19F23 /* AsyncData.swift */; };
 		B6A79DF02204E24500059604 /* AsyncDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D3D2CA2203B02700B19F23 /* AsyncDataTask.swift */; };
 		B6D3D2CB2203B02700B19F23 /* AsyncDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D3D2CA2203B02700B19F23 /* AsyncDataTask.swift */; };
@@ -83,6 +85,8 @@
 		17D187961AB0B173000742BF /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		17D187991AB0B173000742BF /* ELWebService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ELWebService.h; sourceTree = "<group>"; };
 		3E8CA4B520E587CB00CBDA69 /* ELWebService.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ELWebService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5A738AB8234E564E00643BF7 /* StringValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringValue.swift; sourceTree = "<group>"; };
+		5A738ABC234E5BE700643BF7 /* HTTP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTP.swift; sourceTree = "<group>"; };
 		B6D3D2CA2203B02700B19F23 /* AsyncDataTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncDataTask.swift; sourceTree = "<group>"; };
 		B6D3D2CC2203BE6B00B19F23 /* AsyncDataTaskTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncDataTaskTests.swift; sourceTree = "<group>"; };
 		B6D3D2CE2203C70400B19F23 /* AsyncData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncData.swift; sourceTree = "<group>"; };
@@ -186,6 +190,8 @@
 				17BA678E1C8416C500A26309 /* Session.swift */,
 				17088EDF1C5011FB007ADE1B /* WebService.swift */,
 				17D064681F3425A6007E1035 /* ServiceTaskMetrics.swift */,
+				5A738AB8234E564E00643BF7 /* StringValue.swift */,
+				5A738ABC234E5BE700643BF7 /* HTTP.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -365,6 +371,8 @@
 				17BA678F1C8416C500A26309 /* Session.swift in Sources */,
 				17547AD61C6121E200D4B030 /* ServiceTask+ObjC.swift in Sources */,
 				1720E8241C6A483100DBB925 /* ServicePassthroughDelegate.swift in Sources */,
+				5A738ABD234E5BE700643BF7 /* HTTP.swift in Sources */,
+				5A738AB9234E564E00643BF7 /* StringValue.swift in Sources */,
 				17D064691F3425A6007E1035 /* ServiceTaskMetrics.swift in Sources */,
 				B6D3D2CF2203C70400B19F23 /* AsyncData.swift in Sources */,
 				CAF0AF9B1C5054E60007761C /* ServiceTaskResult.swift in Sources */,

--- a/ELWebService.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ELWebService.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ELWebServiceTests/RequestTests.swift
+++ b/ELWebServiceTests/RequestTests.swift
@@ -45,10 +45,10 @@ class RequestTests: XCTestCase {
         
         XCTAssertEqual(request.headers["Content-Type"]!, contentType)
         XCTAssertEqual(request.headers["User-Agent"]!, userAgent)
-        XCTAssertEqual(Request.Headers.userAgent, "User-Agent")
-        XCTAssertEqual(Request.Headers.contentType, "Content-Type")
-        XCTAssertEqual(Request.Headers.accept, "Accept")
-        XCTAssertEqual(Request.Headers.cacheControl, "Cache-Control")
+        XCTAssertEqual(HTTP.Header.userAgent.stringValue, "User-Agent")
+        XCTAssertEqual(HTTP.Header.contentType.stringValue, "Content-Type")
+        XCTAssertEqual(HTTP.Header.accept.stringValue, "Accept")
+        XCTAssertEqual(HTTP.Header.cacheControl.stringValue, "Cache-Control")
     }
     
     func test_headerProperties_getValuesFromTheCorrectHeaderFields() {
@@ -96,7 +96,7 @@ class RequestTests: XCTestCase {
         
         request.parameterEncoding = .json
         
-        XCTAssertEqual(request.contentType, Request.ContentType.json)
+        XCTAssertEqual(request.contentType, HTTP.ContentType.json.stringValue)
     }
     
     func test_setBody_overwritesExistingBodyData() {
@@ -154,7 +154,7 @@ class RequestTests: XCTestCase {
         request.formParameters = ["percentEncoded" : "this needs percent encoded"]
         
         XCTAssertNotNil(request.contentType)
-        XCTAssertEqual(request.contentType!, Request.ContentType.formEncoded)
+        XCTAssertEqual(request.contentType!, HTTP.ContentType.formEncoded.stringValue)
     }
     
     func test_formParameters_encodesDataInRequestBody() {
@@ -196,7 +196,7 @@ class RequestTests: XCTestCase {
         test_urlRequestValue_parametersInURL(.DELETE)
     }
     
-    func test_urlRequestValue_parametersInURL(_ method: Request.Method) {
+    func test_urlRequestValue_parametersInURL(_ method: HTTP.Method) {
         var request = Request(method, url: "http://httpbin.org/")
         request.parameters = ["x" : "1"]
         
@@ -210,7 +210,7 @@ class RequestTests: XCTestCase {
         test_urlRequestValue_parametersInBody(.POST)
     }
     
-    func test_urlRequestValue_parametersInBody(_ method: Request.Method) {
+    func test_urlRequestValue_parametersInBody(_ method: HTTP.Method) {
         var request = Request(method, url: "http://httpbin.org/")
         request.parameters = ["x" : "1"]
         

--- a/ELWebServiceTests/ServiceTaskTests.swift
+++ b/ELWebServiceTests/ServiceTaskTests.swift
@@ -709,7 +709,7 @@ extension ServiceTaskTests {
         let recordedURLRequest = session.recordedRequests.first?.urlRequestValue
         XCTAssertNotNil(recordedURLRequest)
         XCTAssertEqual(recordedURLRequest!.httpBody, bodyData)
-        XCTAssertEqual(recordedURLRequest?.allHTTPHeaderFields?[Request.Headers.contentType], contentType)
+        XCTAssertEqual(recordedURLRequest?.allHTTPHeaderFields?[HTTP.Header.contentType.stringValue], contentType)
     }
 
 
@@ -876,7 +876,7 @@ extension ServiceTaskTests {
         let recordedURLRequest = session.recordedRequests.first?.urlRequestValue
         XCTAssertNotNil(recordedURLRequest)
         XCTAssertEqual(recordedURLRequest!.httpBody, bodyData)
-        XCTAssertEqual(recordedURLRequest?.allHTTPHeaderFields?[Request.Headers.contentType], contentType)
+        XCTAssertEqual(recordedURLRequest?.allHTTPHeaderFields?[HTTP.Header.contentType.stringValue], contentType)
     }
     
     // setParameters

--- a/Source/Core/HTTP.swift
+++ b/Source/Core/HTTP.swift
@@ -1,0 +1,80 @@
+//
+//  HTTP.swift
+//  ELWebService
+//
+//  Created by Manoj Kumar Mahapatra on 10/9/19.
+//  Copyright © 2019 WalmartLabs. All rights reserved.
+//
+
+import Foundation
+
+public enum HTTP {}
+
+extension HTTP {
+    /// HTTP header files are components of the header section of request and response messages in the HTTP
+    struct Header: Hashable, StringValue {
+        let stringValue: String
+        fileprivate init(_ value: String) { stringValue = value }
+    }
+}
+
+extension HTTP.Header {
+    /// Used by requests to specify the user agent
+    static let userAgent = HTTP.Header("User-Agent")
+    /// Used by requests to specify the `HTTP.ContentType` of the request body
+    /// and by responses to specify the `HTTP.ContentType` of the response body
+    static let contentType = HTTP.Header("Content-Type")
+    /// The length of the request body
+    static let contentLength = HTTP.Header("Content-Length")
+    /// Used by requests to specify the `HTTP.ContentType`s that are acceptable responses
+    static let accept = HTTP.Header("Accept")
+    /// Used to specify directives that must be obeyed by all caching mechanisms along the request-response chain
+    static let cacheControl = HTTP.Header("Cache-Control")
+}
+
+extension HTTP {
+    /// Represents valid values for `HTTP.Header.contentType`
+    struct ContentType: Hashable, StringValue {
+        let stringValue: String
+        fileprivate init(_ value: String) { stringValue = value }
+    }
+}
+
+extension HTTP.ContentType {
+    /// The content type used by html forms
+    static let formEncoded = HTTP.ContentType("application/x-www-form-urlencoded")
+    /// The content type used for json
+    static let json = HTTP.ContentType("application/json")
+}
+
+extension HTTP {
+    /// The `Method` enum defines the supported HTTP methods.
+    public enum Method: String, CaseIterable {
+        /// The `GET` method requests a representation of the specified resource
+        case GET = "GET"
+        /// The `HEAD` method asks for a response identical to that of a GET request, but without the response body
+        case HEAD = "HEAD"
+        /// The `POST` method requests that the server accept the entity enclosed in the request as a new
+        /// subordinate of the web resource identified by the URI
+        case POST = "POST"
+        /// The `PUT` method requests that the enclosed entity be stored under the supplied URI
+        case PUT = "PUT"
+        /// The `PATCH` method applies partial modifications to a resource
+        case PATCH = "PATCH"
+        /// The `DELETE` method deletes the specified resource.
+        case DELETE = "DELETE"
+        
+        /// Whether requests using this method should encode parameters in the URL, instead of the body.
+        ///
+        /// `GET`, `HEAD` and `DELETE` requests encode parameters in the URL, `PUT`, `POST` and `PATCH` encode
+        /// them in the body.
+        func encodesParametersInURL() -> Bool {
+            switch self {
+            case .GET, .HEAD, .DELETE:
+                return true
+            default:
+                return false
+            }
+        }
+    }
+}

--- a/Source/Core/Request.swift
+++ b/Source/Core/Request.swift
@@ -19,32 +19,6 @@ public typealias QueryParameterEncoder = (_ url: URL?, _ parameters: [String: An
  Encapsulates the data required to send an HTTP request.
 */
 public struct Request {
-    
-    /// The `Method` enum defines the supported HTTP methods.
-    public enum Method: String {
-        case GET = "GET"
-        case HEAD = "HEAD"
-        case POST = "POST"
-        case PUT = "PUT"
-        case PATCH = "PATCH"
-        case DELETE = "DELETE"
-
-        /**
-         Whether requests using this method should encode parameters in the URL, instead of the body.
-
-         `GET`, `HEAD` and `DELETE` requests encode parameters in the URL, `PUT`, `POST` and `PATCH` encode
-         them in the body.
-         */
-        func encodesParametersInURL() -> Bool {
-            switch self {
-            case .GET, .HEAD, .DELETE:
-                return true
-            default:
-                return false
-            }
-        }
-    }
-    
     // MARK: Parameter Encodings
     
     /// A `ParameterEncoding` value defines how to encode request parameters
@@ -89,24 +63,8 @@ public struct Request {
         }
     }
     
-    /// A group of static constants for referencing HTTP header field names.
-    public struct Headers {
-        public static let userAgent = "User-Agent"
-        public static let contentType = "Content-Type"
-        public static let contentLength = "Content-Length"
-        public static let accept = "Accept"
-        public static let cacheControl = "Cache-Control"
-    }
-    
-    /// A group of static constants for referencing supported HTTP 
-    /// `Content-Type` header values.
-    public struct ContentType {
-        public static let formEncoded = "application/x-www-form-urlencoded"
-        public static let json = "application/json"
-    }
-        
     /// The HTTP method of the request.
-    public let method: Method
+    public let method: HTTP.Method
     
     public let requestURL: URL
 
@@ -137,7 +95,7 @@ public struct Request {
         didSet {
             if let formData = formParameters?.percentEncodedData(with: formParametersAllowedCharacters) {
                 body = formData
-                contentType = ContentType.formEncoded
+                contentType = HTTP.ContentType.formEncoded.stringValue
             }
         }
     }
@@ -164,21 +122,21 @@ public struct Request {
     public var parameterEncoding = ParameterEncoding.percent {
         didSet {
             if parameterEncoding == .json {
-                contentType = ContentType.json
+                contentType = HTTP.ContentType.json.stringValue
             }
         }
     }
     
     /// The HTTP `Content-Type` header field value of the request.
     var contentType: String? {
-        set { headers[Headers.contentType] = newValue }
-        get { return headers[Headers.contentType] }
+        set { headers[HTTP.Header.contentType.stringValue] = newValue }
+        get { return headers[HTTP.Header.contentType.stringValue] }
     }
     
     /// The HTTP `User-Agent` header field value of the request.
     var userAgent: String? {
-        set { headers[Headers.userAgent] = newValue }
-        get { return headers[Headers.userAgent] }
+        set { headers[HTTP.Header.userAgent.stringValue] = newValue }
+        get { return headers[HTTP.Header.userAgent.stringValue] }
     }
     
     // MARK: Initialization
@@ -189,7 +147,7 @@ public struct Request {
      - parameter method: The HTTP request method.
      - parameter url: The URL string of the HTTP request.
      */
-    init(_ method: Method, url: URL) {
+    init(_ method: HTTP.Method, url: URL) {
         self.method = method
         self.requestURL = url
     }
@@ -200,7 +158,7 @@ public struct Request {
      - parameter method: The HTTP request method.
      - parameter url: The URL string of the HTTP request.
     */
-    init(_ method: Method, url urlString: String) {
+    init(_ method: HTTP.Method, url urlString: String) {
         let aURL = URL(string: urlString)!
         self.init(method, url: aURL)
     }
@@ -233,8 +191,8 @@ extension Request: URLRequestEncodable {
                 if let data = parameterEncoding.encodeBody(parameters) {
                     urlRequest.httpBody = data
                     
-                    if urlRequest.value(forHTTPHeaderField: Headers.contentType) == nil {
-                        urlRequest.setValue(ContentType.formEncoded, forHTTPHeaderField: Headers.contentType)
+                    if urlRequest.value(forHTTPHeaderField: HTTP.Header.contentType.stringValue) == nil {
+                        urlRequest.setValue(HTTP.ContentType.formEncoded.stringValue, forHTTPHeaderField: HTTP.Header.contentType.stringValue)
                     }
                 }
             }

--- a/Source/Core/ServiceTask.swift
+++ b/Source/Core/ServiceTask.swift
@@ -155,7 +155,7 @@ extension ServiceTask {
 
     /// TODO: Needs docs
     @discardableResult public func setJSON(_ json: Any) -> Self {
-        request.contentType = Request.ContentType.json
+        request.contentType = HTTP.ContentType.json.stringValue
         request.body = try? JSONSerialization.data(withJSONObject: json, options: JSONSerialization.WritingOptions(rawValue: 0))
         return self
     }
@@ -166,7 +166,7 @@ extension ServiceTask {
     /// - Parameter json: A `Data` instance containing JSON data.
     /// - Returns: `self`
     @discardableResult public func setJSONData(_ json: Data) -> Self {
-        return setBody(json, contentType: Request.ContentType.json)
+        return setBody(json, contentType: HTTP.ContentType.json.stringValue)
     }
     
     /// TODO: Needs docs
@@ -286,7 +286,7 @@ extension ServiceTask {
     ///   - contentType: The `Content-Type` header value describing the type of `data`.
     /// - Returns: `self`
     @discardableResult func setJSONData(_ provideBody: @escaping AsyncDataProvider) -> Self {
-        return setBody(provideBody, contentType: Request.ContentType.json)
+        return setBody(provideBody, contentType: HTTP.ContentType.json.stringValue)
     }
 }
 

--- a/Source/Core/StringValue.swift
+++ b/Source/Core/StringValue.swift
@@ -1,0 +1,45 @@
+//
+//  StringValue.swift
+//  ELWebService
+//
+//  Created by Manoj Kumar Mahapatra on 10/9/19.
+//  Copyright © 2019 WalmartLabs. All rights reserved.
+//
+
+import Foundation
+
+/// Types with obvious representation as a `String` should be conforming to this protocol.
+public protocol StringValue {
+    var stringValue: String { get }
+}
+
+extension String: StringValue {
+    public var stringValue: String {
+        return self
+    }
+}
+extension StaticString: StringValue {
+    public var stringValue: String {
+        return "\(self)"
+    }
+}
+extension Substring: StringValue {
+    public var stringValue: String {
+        return String(self)
+    }
+}
+extension URL: StringValue {
+    public var stringValue: String {
+        return absoluteString
+    }
+}
+extension Int: StringValue {
+    public var stringValue: String {
+        return "\(self)"
+    }
+}
+extension Bool: StringValue {
+    public var stringValue: String {
+        return self ? "true" : "false"
+    }
+}

--- a/Source/Core/WebService.swift
+++ b/Source/Core/WebService.swift
@@ -180,7 +180,7 @@ extension WebService {
      - returns: A ServiceTask instance that refers to the lifetime of processing
      a given request.
      */
-    public func request(_ method: Request.Method, path: String) -> ServiceTask {
+    public func request(_ method: HTTP.Method, path: String) -> ServiceTask {
         return serviceTask(request: Request(method, url: absoluteURL(path)))
     }
 


### PR DESCRIPTION
**Motivation** 💡

This PR intends to abstract `(HTTP)Method`, `Headers`, `ContentType` to a separate file under a common namespace `HTTP`. Namespacing is _pretty_ powerful when it comes to code structuring. Not only that the proposed changes also intend to prevent any name collision and provides encapsulation for `HTTP`.

Also extracting out `HTTP` to its own namespace will flesh out a _strongly_ typed `HTTP` header models in the future if/when we have more sophisticated use of headers.  Also, it makes sense to keep `Method`, `ContentType` and `Header` under `HTTP` namespace cus each of them defines the operating parameters of an `HTTP` transaction (https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol).

```swift
enum HTTP {
   struct Header {} 
}
```
It allows name relative access when using extensions and within the namespace, but makes sure that the calling side uses the actual name and allows the user to identify what kind of `header` the code is talking about.

**Choosing Enum** 💪

Enums do not have synthesized initializers, unline classes they do not allow for subclassing hence making them a good candidate for namespacing. 

**Breaking Changes** 🚨

There will be *breaking* changes since `Method` is moved under a common namespace `HTTP`. The only types that are now not `public` are the constants defined under various `HTTP` components. The above results are based on my initial smoke testing w/ the current changes by replacing locally the framework.

I should be more pro-active by creating an issue or discussion before opening this PR and I'm really sorry for that @angelodipaolo. 

Please let me know if you guys need any more details or have questions/concerns. Happy to explain.   